### PR TITLE
Change when the ongoingConversation event is fired

### DIFF
--- a/src/state/selectors/is-chat-being-assigned.js
+++ b/src/state/selectors/is-chat-being-assigned.js
@@ -1,0 +1,13 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import get from 'lodash/get';
+
+/**
+ * Internal dependencies
+ */
+import { HAPPYCHAT_CHAT_STATUS_ASSIGNING } from 'src/state/constants';
+
+export default state => get( state, 'chat.status' ) === HAPPYCHAT_CHAT_STATUS_ASSIGNING;

--- a/targets/wordpress/plugin/assets/happychat-init.js
+++ b/targets/wordpress/plugin/assets/happychat-init.js
@@ -24,14 +24,19 @@ if ( window.Happychat ) {
 	jQuery( happychat ).css( 'display', 'none' );
 	Happychat.open( 'happychat-form', happychatSettings.groups, happychatSettings.token );
 
-	Happychat.on( 'availability', function( isAvailable ) {
-		console.log( 'isAvailable: ', isAvailable );
-		if ( ! happychatSettings.hasOngoingConversation ) {
-			isAvailable ? showHappychat() : showTicketForm();
+	var isHappychatAvailable = false;
+	var hasOngoingConversation = false;
+	var changeHappychatVisibility = function( availability, conversation ) {
+		if ( ! conversation ) {
+			availability ? showHappychat() : showTicketForm();
 		}
+	};
+	Happychat.on( 'availability', function( newStatus ) {
+		isHappychatAvailable = newStatus;
+		changeHappychatVisibility( isHappychatAvailable, hasOngoingConversation );
 	} );
-
-	Happychat.on( 'ongoingConversation', function( hasOngoingConversation ) {
-		happychatSettings.ongoingConversation = hasOngoingConversation;
+	Happychat.on( 'ongoingConversation', function( newStatus ) {
+		hasOngoingConversation = newStatus;
+		changeHappychatVisibility( isHappychatAvailable, hasOngoingConversation );
 	} );
 }


### PR DESCRIPTION
Some clients hide the chat form status if the availability is false, but they don't want to hide it if there is an ongoingConversation.

When an operator has 1 spot left, we're going to call subscribers with availability=false and ongoingConversation=true. But because the availability event happens before the chatStatus is "assigned",
we need to consider the "assigning" chatStatus as an ongoingConversation, to prevent the race condition.