### PR TITLE
Style the chat form so it can be told apart from a bare webpage

### DIFF
--- a/src/ui/form.scss
+++ b/src/ui/form.scss
@@ -1,6 +1,7 @@
 /** @format */
 
 @import 'css/shared/colors';
+@import 'css/shared/typography';
 
 // experiment: style scrollbars
 .happychat__page {
@@ -21,18 +22,29 @@
 	}
 }
 
-// override colors
+// override colors and fonts
 .happychat__page {
 	background-color: $gray-light;
+	font-family: $sans;
+	font-size: 14px;
+	border: 1px solid lighten( $gray, 25% );
 }
 
 // make textarea to fill the whole box
 .happychat__message > textarea {
-       width: 100%;
+	width: 100%;
+	box-sizing: border-box;
 }
 
+// small tweaks to conversation container
 .happychat__conversation {
-	height: 50vh;
+	padding-left: 6px;
+	padding-right: 6px;
+}
+
+// clean grey border on submit button
+.happychat__submit {
+	border: 0;
 }
 
 @import 'components/emojify/style';

--- a/src/ui/form.scss
+++ b/src/ui/form.scss
@@ -27,7 +27,7 @@
 	background-color: $gray-light;
 	font-family: $sans;
 	font-size: 14px;
-	border: 1px solid lighten( $gray, 25% );
+	border: 1px solid lighten($gray, 25%);
 }
 
 // make textarea to fill the whole box
@@ -38,6 +38,7 @@
 
 // small tweaks to conversation container
 .happychat__conversation {
+	height: 50vh; // set height so it can be scrolled
 	padding-left: 6px;
 	padding-right: 6px;
 }


### PR DESCRIPTION
Changes aren't dramatic, just a small tweak in the font and a few borders/paddings, but it's basically the same. Should we incorporate a header to differentiate it even more?

Before:
![screen shot 2017-12-28 at 15 45 21](https://user-images.githubusercontent.com/820374/34413966-e6fdd908-ebe6-11e7-9e7e-72b1828d0ef9.png)

After:
![screen shot 2017-12-28 at 15 45 05](https://user-images.githubusercontent.com/820374/34413971-eb7b4920-ebe6-11e7-8078-84d1cde0a167.png)
