### PR TITLE
Update/wordpress/hooks

### DIFF
--- a/targets/wordpress/plugin/README.md
+++ b/targets/wordpress/plugin/README.md
@@ -1,16 +1,66 @@
 # Happychat as a WordPress plugin
 
-This WordPress plugin provides a `happychat` shortcode that will render the Happychat component in any page or post it is included.
+This WordPress plugin provides a `happychat` shortcode that will render the Happychat component in any page or post it is included. It may be configured through the `happychat_settings` filter.
 
 It will make authenticated requests to WordPress.com on the user behalf to start a chat session. See [WordPress.com OAuth2](https://developer.wordpress.com/docs/oauth2/) for the details. In essence, what this means is that:
 
-* the host origin should be allowed to make authenticated requests to WordPress.com, for which a WordPress.com app needs to be registered with the host as valid JS origin.
-* the plugin needs a WordPress.com user token (`access_token`) that should be provided through the `happychat_wpcom_token` filter.
+* the host should be allowed to make authenticated requests to WordPress.com, for which a WordPress.com app needs to be registered with the host as valid JS origin.
+* the plugin needs a WordPress.com user token, which needs to be provided through the `happychat_settings` filter.
 
-## Filters
+## Happychat Settings
 
-| Tag | Value | Default | Description |
+The Happychat behavior may be configured through the filter `happychat_settings` that returns an array with the following options.
+
+| Key | Value | Default | Description |
 | --- | --- | --- | --- |
-| `happychat_is_user_eligible` | boolean `$eligibility` | `true` | Whether the user is eligible for a chat session. |
-| `happychat_user_group` | string `$group` | `WP.com` | What group the chat session should be routed to. Valid values are `WP.com`, `woo`, and `jpop`. |
-| `happychat_wpcom_token` | string `$token` | `null` | A valid WordPress.com token to make authenticated request on the user behalf. Happychat will not be renderer if the token is not provided. |
+| `accessToken` | string | `null` | A valid WordPress.com token to make authenticated request on the user behalf. Happychat will not be renderer if the token is not provided. |
+| `entry` | string | `ENTRY_FORM` | What should be rendered as the entry point for Happychat. Valid values are `ENTRY_FORM` (renders the contact form) `ENTRY_CHAT` (renders the chat form). |
+| `entryOptions` | array | `[]` | Array containing the options to configure happychat entry points. See details below. |
+| `groups` | array | `[WP.com]` | What group the chat session should be routed to. Valid values are `WP.com`, `woo`, and `jpop`. |
+| `nodeId` | string | `happychat-form` | The id of the HTMLNode where Happychat will be rendered. |
+
+### Entry options
+
+`primaryOptions`: array containing key/value pairs to show as the contact form primary options. For example:
+
+	$happychat_settings = [
+		'entryOptions' => [
+			'primaryOptions': [
+				[ 'value' => 'before-buy', 'label' => 'Before you buy' ],
+				[ 'value' => 'account',    'label' => 'My account' ],
+				[ 'value' => 'purchases',  'label' => 'Purchases' ],
+			],
+		],
+	];
+
+`secondaryOptions`: array containing key/value pairs to show as the contact form secondary options. For example:
+
+	$happychat_settings = [
+		'entryOptions' => [
+			'secondaryOptions': [
+				[ 'value' => 'before-buy', 'label' => 'Before you buy' ],
+				[ 'value' => 'account',    'label' => 'My account' ],
+				[ 'value' => 'purchases',  'label' => 'Purchases' ],
+			],
+		],
+	];
+
+`fallbackTicket`: object to configure the fallback ticket feature.
+
+* `pathToCreate`: path to the create ticket endpoint where Happychat will make a XHR request with the form data, so the host can process it. It may return an operation ID that will be used by the `pathToShow` option to show a message to the user.
+
+* `headers`: request headers to be sent along the `pathToCreate` request. This allows for hooking nonces into the request, for example.
+
+* `pathToShow`: upon a successful response from the `pathToCreate` endpoint, Happychat can show a link to the ticket created if one is configured. This admits a `<ticket-id>` expression that will be filled with the response provided by the `pathToCreate` endpoint.
+
+For example:
+
+	$happychat_settings = [
+		'fallbackTicket' => [
+			'pathToCreate' => '/create-ticket',
+			'pathToShow'   => '/show-ticket/<ticket-id>',
+			'headers'      => [
+				'X-WP-Nonce' => wp_create_nonce( 'wp_rest' )
+			]
+		]
+	];

--- a/targets/wordpress/plugin/assets/client-happychat-init.js
+++ b/targets/wordpress/plugin/assets/client-happychat-init.js
@@ -10,8 +10,9 @@
 
 window.Happychat &&
 	Happychat.open( {
-		accessToken: happychatSettings.token,
 		nodeId: happychatSettings.nodeId,
+		accessToken: happychatSettings.accessToken,
 		groups: happychatSettings.groups,
+		entry: happychatSettings.entry,
 		entryOptions: happychatSettings.entryOptions,
 	} );

--- a/targets/wordpress/plugin/class-happychat-client.php
+++ b/targets/wordpress/plugin/class-happychat-client.php
@@ -113,16 +113,16 @@ class Happychat_Client {
 					array( 'value' => 'config', 'label' => 'Help configuring' ),
 					array( 'value' => 'order', 'label' => 'Help with an order' ),
 					array( 'value' => 'broken', 'label' => 'Something is broken' ),
-					],
-					'fallbackTicket' => array(
-						'pathToCreate' => $fallback_ticket_path_create,
-						'pathToShow' => $fallback_ticket_path_show,
-						'headers' => array( 'X-WP-Nonce' => wp_create_nonce( 'wp_rest' ) ),
-					),
-					],
-				);
+				],
+				'fallbackTicket' => array(
+					'pathToCreate' => $fallback_ticket_path_create,
+					'pathToShow' => $fallback_ticket_path_show,
+					'headers' => array( 'X-WP-Nonce' => wp_create_nonce( 'wp_rest' ) ),
+				),
+			],
+		);
 
-				wp_localize_script( 'happychat-init', 'happychatSettings', $happychat_settings );
-				wp_enqueue_script( 'happychat-init' );
-			}
-		}
+		wp_localize_script( 'happychat-init', 'happychatSettings', $happychat_settings );
+		wp_enqueue_script( 'happychat-init' );
+	}
+}

--- a/targets/wordpress/plugin/class-happychat-client.php
+++ b/targets/wordpress/plugin/class-happychat-client.php
@@ -49,7 +49,7 @@ class Happychat_Client {
 	private function is_valid_entry( $entry ) {
 		// These are the accepted values for Happychat entries
 		// https://github.com/Automattic/happychat-client/blob/master/src/form.js#L62
-		if ( ( 'ENTRY_FORM' === $entry  ) || ( 'ENTRY_CHAT' === $entry ) ) {
+		if ( ( 'form' === $entry  ) || ( 'chat' === $entry ) ) {
 			return true;
 		}
 		return false;
@@ -64,7 +64,7 @@ class Happychat_Client {
 
 	private function validate_entry( $entry ) {
 		if ( ! $entry || ! $this->is_valid_entry( $group ) ) {
-			$entry = 'ENTRY_FORM';
+			$entry = 'form';
 		}
 		return $entry;
 	}

--- a/targets/wordpress/plugin/class-happychat-client.php
+++ b/targets/wordpress/plugin/class-happychat-client.php
@@ -29,12 +29,12 @@ class Happychat_Client {
 		// The host should provide a valid WordPress.com token
 		// for the user, so we can make authenticated requests
 		// on its behalf.
-		if ( ! $happychat_settings[ 'accessToken' ] ) {
+		if ( ! $happychat_settings['accessToken'] ) {
 			return '';
 		}
 
 		$this->enqueue_scripts( $happychat_settings );
-		return '<div id="' . $happychat_settings[ 'nodeId' ] . '"></div>';
+		return '<div id="' . $happychat_settings['nodeId'] . '"></div>';
 	}
 
 	private function is_valid_group( $group ) {
@@ -79,7 +79,7 @@ class Happychat_Client {
 		return $new_path;
 	}
 
-	private function get_happychat_settings( ) {
+	private function get_happychat_settings() {
 		$happychat_settings = [
 			'accessToken' => null,
 			'entry' => 'ENTRY_FORM',
@@ -90,10 +90,10 @@ class Happychat_Client {
 
 		$happychat_settings = apply_filters( 'happychat_settings', $happychat_settings );
 
-		$happychat_settings[ 'entry' ] = $this->validate_entry( $happychat_settings[ 'entry' ] );
-		$happychat_settings[ 'entryOptions' ][ 'fallbackTicket' ][ 'pathToCreate' ] = $this->validate_path( $happychat_settings[ 'entryOptions' ][ 'fallbackTicket' ][ 'pathToCreate' ] );
-		$happychat_settings[ 'entryOptions' ][ 'fallbackTicket' ][ 'pathToShow' ] = $this->validate_path( $happychat_settings[ 'entryOptions' ][ 'fallbackTicket' ][ 'pathToShow' ] );
-		$happychat_settings[ 'groups' ] = [ $this->validate_group( $happychat_settings[ 'groups' ][ 0 ] ) ];
+		$happychat_settings['entry'] = $this->validate_entry( $happychat_settings['entry'] );
+		$happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] = $this->validate_path( $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] );
+		$happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] = $this->validate_path( $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] );
+		$happychat_settings['groups'] = [ $this->validate_group( $happychat_settings['groups'][0] ) ];
 
 		return $happychat_settings;
 	}


### PR DESCRIPTION
This simplifies the happychat WordPress plugin hooks, reducing them to only one, `happychat_settings`.

Closes https://github.com/Automattic/happychat-client/issues/101