### PR TITLE
check entryOptions ticket paths before accessing array keys

### DIFF
--- a/targets/wordpress/class-happychat-client.php
+++ b/targets/wordpress/class-happychat-client.php
@@ -96,13 +96,14 @@ class Happychat_Client {
 
 		$happychat_settings = apply_filters( 'happychat_settings', $happychat_settings );
 
+		$happychat_settings['entry']  = $this->validate_entry( $happychat_settings['entry'] );
+
 		$path_to_create = isset( $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] ) ? $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] : null;
 		$path_to_show   = isset( $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] ) ? $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] : null;
 
 		$happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] = $this->validate_path( $path_to_create );
 		$happychat_settings['entryOptions']['fallbackTicket']['pathToShow']   = $this->validate_path( $path_to_show );
 
-		$happychat_settings['entry']  = $this->validate_entry( $happychat_settings['entry'] );
 		$happychat_settings['groups'] = [ $this->validate_group( $happychat_settings['groups'][0] ) ];
 
 		return $happychat_settings;

--- a/targets/wordpress/class-happychat-client.php
+++ b/targets/wordpress/class-happychat-client.php
@@ -107,7 +107,6 @@ class Happychat_Client {
 		$happychat_settings['groups'] = [ $this->validate_group( $happychat_settings['groups'][0] ) ];
 
 		return $happychat_settings;
-
 	}
 
 	private function enqueue_scripts( $happychat_settings ) {
@@ -133,4 +132,3 @@ class Happychat_Client {
 		wp_enqueue_script( 'happychat-init' );
 	}
 }
-

--- a/targets/wordpress/class-happychat-client.php
+++ b/targets/wordpress/class-happychat-client.php
@@ -99,13 +99,14 @@ class Happychat_Client {
 		$path_to_create = isset( $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] ) ? $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] : null;
 		$path_to_show   = isset( $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] ) ? $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] : null;
 
-		$happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] = $this->validate_path( $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] );
-		$happychat_settings['entryOptions']['fallbackTicket']['pathToShow']   = $this->validate_path( $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] );
+		$happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] = $this->validate_path( $path_to_create );
+		$happychat_settings['entryOptions']['fallbackTicket']['pathToShow']   = $this->validate_path( $path_to_show );
 
 		$happychat_settings['entry']  = $this->validate_entry( $happychat_settings['entry'] );
 		$happychat_settings['groups'] = [ $this->validate_group( $happychat_settings['groups'][0] ) ];
 
 		return $happychat_settings;
+
 	}
 
 	private function enqueue_scripts( $happychat_settings ) {

--- a/targets/wordpress/class-happychat-client.php
+++ b/targets/wordpress/class-happychat-client.php
@@ -96,9 +96,13 @@ class Happychat_Client {
 
 		$happychat_settings = apply_filters( 'happychat_settings', $happychat_settings );
 
-		$happychat_settings['entry'] = $this->validate_entry( $happychat_settings['entry'] );
+		$path_to_create = isset( $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] ) ? $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] : NULL;
+		$path_to_show   = isset( $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] ) ? $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] : NULL;
+
 		$happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] = $this->validate_path( $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] );
 		$happychat_settings['entryOptions']['fallbackTicket']['pathToShow']   = $this->validate_path( $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] );
+
+		$happychat_settings['entry']  = $this->validate_entry( $happychat_settings['entry'] );
 		$happychat_settings['groups'] = [ $this->validate_group( $happychat_settings['groups'][0] ) ];
 
 		return $happychat_settings;
@@ -127,3 +131,4 @@ class Happychat_Client {
 		wp_enqueue_script( 'happychat-init' );
 	}
 }
+

--- a/targets/wordpress/class-happychat-client.php
+++ b/targets/wordpress/class-happychat-client.php
@@ -96,8 +96,8 @@ class Happychat_Client {
 
 		$happychat_settings = apply_filters( 'happychat_settings', $happychat_settings );
 
-		$path_to_create = isset( $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] ) ? $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] : NULL;
-		$path_to_show   = isset( $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] ) ? $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] : NULL;
+		$path_to_create = isset( $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] ) ? $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] : null;
+		$path_to_show   = isset( $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] ) ? $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] : null;
 
 		$happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] = $this->validate_path( $happychat_settings['entryOptions']['fallbackTicket']['pathToCreate'] );
 		$happychat_settings['entryOptions']['fallbackTicket']['pathToShow']   = $this->validate_path( $happychat_settings['entryOptions']['fallbackTicket']['pathToShow'] );


### PR DESCRIPTION
This array is provided by the host. In certain cases they may not specify a value that we expect. So this PR double checks that these values we expect do actually exist.