### PR TITLE
Sets up a client that can be used for scripting

### DIFF
--- a/src/headless.js
+++ b/src/headless.js
@@ -1,0 +1,38 @@
+/**
+ * External Dependencies
+ */
+import { createStore, applyMiddleware } from 'redux';
+
+/**
+ * Internal Dependencies
+ */
+import reducer from 'src/state/reducer';
+import { socketMiddleware } from 'src/state/middleware';
+import WPComOauth from '../src/lib/auth/strategies/wpcom/oauth';
+import { setCurrentUser } from '../src/state/user/actions';
+import { initConnection } from '../src/state/connection/actions';
+
+const createHappychatStore = () => {
+	return createStore(
+		reducer,
+		{},
+		applyMiddleware( socketMiddleware() )
+	);
+};
+
+export default authorize = ( token ) => {
+	const api = createHappychatStore();
+	const start = async () => {
+		const auth = new WPComOauth( {
+			type: 'wpcom-oauth-by-token',
+			options: { token }
+		} );
+		auth.login();
+		await auth.getUser();
+
+		api.dispatch( setCurrentUser( await auth.getUser() ) );
+		api.dispatch( initConnection( auth.authorizeChat( api.getState() )() ) ) ;
+	}
+	start();
+	return api;
+};


### PR DESCRIPTION
For testing purposes we can reuse this client for scripting and automated testing against running
services.

It assumes you will be using oauth since it won't be running in a browser with access to the proxy iframe API.

```js
import startClient from '../src/headless';

const store = startClient( process.env.TOKEN );

// pseudo-ish code
store.dispatch( { type: 'HAPPYCHAT_IO_SEND_MESSAGE', message: 'hi' } );
```