### PR TITLE
Fix colors after libsass regression

### DIFF
--- a/src/ui/css/themes/_jpop.scss
+++ b/src/ui/css/themes/_jpop.scss
@@ -4,26 +4,26 @@
 @import '../shared/functions/tint-and-shade';
 
 :root {
-	--selected: $green-jetpack;
-	--selected-darken-5: darken($green-jetpack, 5%);
-	--selected-darken-8: darken($green-jetpack, 8%);
-	--selected-lighten-5: lighten($green-jetpack, 5%);
-	--selected-lighten-10: lighten($green-jetpack, 10%);
-	--selected-tint-20: tint($green-jetpack, 20%);
-	--active: $green-jetpack;
-	--active-opacity-7: rgba($green-jetpack, 0.7);
-	--focused: $green-jetpack;
-	--neutral: $gray;
-	--neutral-opacity-5: rgba($gray, 0.5);
-	--neutral-light: $gray-light;
-	--neutral-dark: $gray-dark;
-	--neutral-dark-lighten-20: lighten($gray-dark, 20%);
-	--neutral-darken-30: darken($gray, 30%);
-	--neutral-lighten-10: lighten($gray, 10%);
-	--neutral-lighten-20: lighten($gray, 20%);
-	--neutral-lighten-20-opacity-5: transparentize(lighten($gray, 20%), 0.5);
-	--neutral-lighten-25: lighten($gray, 25%);
-	--neutral-lighten-30: lighten($gray, 30%);
-	--text: $gray-dark;
-	--text-min: darken($gray, 18%);
+	--selected: #{$green-jetpack};
+	--selected-darken-5: #{darken($green-jetpack, 5%)};
+	--selected-darken-8: #{darken($green-jetpack, 8%)};
+	--selected-lighten-5: #{lighten($green-jetpack, 5%)};
+	--selected-lighten-10: #{lighten($green-jetpack, 10%)};
+	--selected-tint-20: #{tint($green-jetpack, 20%)};
+	--active: #{$green-jetpack};
+	--active-opacity-7: #{rgba($green-jetpack, 0.7)};
+	--focused: #{$green-jetpack};
+	--neutral: #{$gray};
+	--neutral-opacity-5: #{rgba($gray, 0.5)};
+	--neutral-light: #{$gray-light};
+	--neutral-dark: #{$gray-dark};
+	--neutral-dark-lighten-20: #{lighten($gray-dark, 20%)};
+	--neutral-darken-30: #{darken($gray, 30%)};
+	--neutral-lighten-10: #{lighten($gray, 10%)};
+	--neutral-lighten-20: #{lighten($gray, 20%)};
+	--neutral-lighten-20-opacity-5: #{transparentize(lighten($gray, 20%), 0.5)};
+	--neutral-lighten-25: #{lighten($gray, 25%)};
+	--neutral-lighten-30: #{lighten($gray, 30%)};
+	--text: #{$gray-dark};
+	--text-min: #{darken($gray, 18%)};
 }

--- a/src/ui/css/themes/_main.scss
+++ b/src/ui/css/themes/_main.scss
@@ -1,26 +1,26 @@
 /** @format */
 
 :root {
-	--selected: $blue-medium;
-	--selected-darken-5: darken($blue-medium, 5%);
-	--selected-darken-8: darken($blue-medium, 8%);
-	--selected-lighten-5: lighten($blue-medium, 5%);
-	--selected-lighten-10: lighten($blue-medium, 10%);
-	--selected-tint-20: tint($blue-medium, 20%);
-	--active: $blue-light;
-	--active-opacity-7: rgba($blue-light, 0.7);
-	--focused: $blue-wordpress;
-	--neutral: $gray;
-	--neutral-opacity-5: rgba($gray, 0.5);
-	--neutral-light: $gray-light;
-	--neutral-dark: $gray-dark;
-	--neutral-dark-lighten-20: lighten($gray-dark, 20%);
-	--neutral-darken-30: darken($gray, 30%);
-	--neutral-lighten-10: lighten($gray, 10%);
-	--neutral-lighten-20: lighten($gray, 20%);
-	--neutral-lighten-20-opacity-5: transparentize(lighten($gray, 20%), 0.5);
-	--neutral-lighten-25: lighten($gray, 25%);
-	--neutral-lighten-30: lighten($gray, 30%);
-	--text: $gray-dark;
-	--text-min: darken($gray, 18%);
+	--selected: #{$blue-medium};
+	--selected-darken-5: #{darken($blue-medium, 5%)};
+	--selected-darken-8: #{darken($blue-medium, 8%)};
+	--selected-lighten-5: #{lighten($blue-medium, 5%)};
+	--selected-lighten-10: #{lighten($blue-medium, 10%)};
+	--selected-tint-20: #{tint($blue-medium, 20%)};
+	--active: #{$blue-light};
+	--active-opacity-7: #{rgba($blue-light, 0.7)};
+	--focused: #{$blue-wordpress};
+	--neutral: #{$gray};
+	--neutral-opacity-5: #{rgba($gray, 0.5)};
+	--neutral-light: #{$gray-light};
+	--neutral-dark: #{$gray-dark};
+	--neutral-dark-lighten-20: #{lighten($gray-dark, 20%)};
+	--neutral-darken-30: #{darken($gray, 30%)};
+	--neutral-lighten-10: #{lighten($gray, 10%)};
+	--neutral-lighten-20: #{lighten($gray, 20%)};
+	--neutral-lighten-20-opacity-5: #{transparentize(lighten($gray, 20%), 0.5)};
+	--neutral-lighten-25: #{lighten($gray, 25%)};
+	--neutral-lighten-30: #{lighten($gray, 30%)};
+	--text: #{$gray-dark};
+	--text-min: #{darken($gray, 18%)};
 }

--- a/src/ui/css/themes/_woo.scss
+++ b/src/ui/css/themes/_woo.scss
@@ -4,26 +4,26 @@
 @import '../shared/functions/tint-and-shade';
 
 :root {
-	--selected: $purple-woo;
-	--selected-darken-5: darken($purple-woo, 5%);
-	--selected-darken-8: darken($purple-woo, 8%);
-	--selected-lighten-5: lighten($purple-woo, 5%);
-	--selected-lighten-10: lighten($purple-woo, 10%);
-	--selected-tint-20: tint($purple-woo, 20%);
-	--active: $purple-woo;
-	--active-opacity-7: rgba($purple-woo, 0.7);
-	--focused: $purple-woo;
-	--neutral: $gray-woo;
-	--neutral-opacity-5: rgba($gray-woo, 0.5);
-	--neutral-light: $gray-light-woo;
-	--neutral-dark: $gray-dark-woo;
-	--neutral-dark-lighten-20: lighten($gray-dark-woo, 20%);
-	--neutral-darken-30: darken($gray-woo, 30%);
-	--neutral-lighten-10: $gray-woo;
-	--neutral-lighten-20: $gray-woo;
-	--neutral-lighten-20-opacity-5: transparentize($gray-woo, 0.5);
-	--neutral-lighten-25: $gray-woo;
-	--neutral-lighten-30: $gray-woo;
-	--text: $gray-dark-woo;
-	--text-min: lighten($gray-dark-woo, 18%);
+	--selected: #{$purple-woo};
+	--selected-darken-5: #{darken($purple-woo, 5%)};
+	--selected-darken-8: #{darken($purple-woo, 8%)};
+	--selected-lighten-5: #{lighten($purple-woo, 5%)};
+	--selected-lighten-10: #{lighten($purple-woo, 10%)};
+	--selected-tint-20: #{tint($purple-woo, 20%)};
+	--active: #{$purple-woo};
+	--active-opacity-7: #{rgba($purple-woo, 0.7)};
+	--focused: #{$purple-woo};
+	--neutral: #{$gray-woo};
+	--neutral-opacity-5: #{rgba($gray-woo, 0.5)};
+	--neutral-light: #{$gray-light-woo};
+	--neutral-dark: #{$gray-dark-woo};
+	--neutral-dark-lighten-20: #{lighten($gray-dark-woo, 20%)};
+	--neutral-darken-30: #{darken($gray-woo, 30%)};
+	--neutral-lighten-10: #{$gray-woo};
+	--neutral-lighten-20: #{$gray-woo};
+	--neutral-lighten-20-opacity-5: #{transparentize($gray-woo, 0.5)};
+	--neutral-lighten-25: #{$gray-woo};
+	--neutral-lighten-30: #{$gray-woo};
+	--text: #{$gray-dark-woo};
+	--text-min: #{lighten($gray-dark-woo, 18%)};
 }


### PR DESCRIPTION
In https://github.com/Automattic/happychat-client/pull/231 we upgraded SocketIO, Node, and a bunch of other dependencies. Among them, node-sass was updated from v4.5.3 to v4.9.0.

node-sass >= 4.8 includes libsass > 3.5.0. libsass 3.5.0 introduced a [backwards incompatibility](http://sass-lang.com/documentation/file.SASS_CHANGELOG.html#Backwards_Incompatibilities_--_Must_Read_) that affected our code.

From 3.5.0 on, CSS variables no longer allow arbitrary SassScript in their values; instead, almost all text in the property values will be passed through unchanged to CSS. The only exception is #{}, which will inject a SassScript value as before.

For example, `--selected: $blue-medium;` will be compiled to `--selected: $blue-medium;` and not to the expected `--selected: #00aadc`.

This affected the way we create the themes (using CSS variables). This PR fixes it by enclosing the SASS variable between `#{}`.

`--selected: $blue-medium` is now `--selected: #{ $blue-medium };`