### PR TITLE
lodash: import module not the full library

### DIFF
--- a/src/ui/components/form-description/index.jsx
+++ b/src/ui/components/form-description/index.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { omit } from 'lodash';
+import omit from 'lodash/omit';
 
 const createMarkup = contents => ( {
 	__html: contents,


### PR DESCRIPTION
This reduces the bundle size by almost 70K parsed and 20K gzipped.

Related https://github.com/Automattic/happychat-client/issues/10