### PR TITLE
Reorder first messages sent to operators

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -148,13 +148,13 @@ class ChatFormComponent {
 		openTextAreaValue,
 	} ) {
 		this.props.onOpenChat();
+		openTextAreaValue && this.props.onSendMessage( openTextAreaTitle + '\n ' + openTextAreaValue );
 		let warmUpMessage = primarySelected.label ? ( primaryOptionsTitle + ' ' + primarySelected.label + '\n' ) : '';
 		warmUpMessage = warmUpMessage + ( secondarySelected.label ? ( secondaryOptionsTitle + ' ' + secondarySelected.label + '\n' ) : '' );
 		warmUpMessage = warmUpMessage + ( itemSelected.label ? ( itemListTitle + ' ' + itemSelected.label + '\n' ) : '' );
 		( warmUpMessage !== '' ) && this.props.onSendMessage( warmUpMessage );
-		this.props.onSendMessage( message );
 		openTextFieldValue && this.props.onSendMessage( openTextFieldTitle + ' ' + openTextFieldValue );
-		openTextAreaValue && this.props.onSendMessage( openTextAreaTitle + '\n ' + openTextAreaValue );
+		this.props.onSendMessage( message );
 	}
 
 	onEvent( formState ) {


### PR DESCRIPTION
- The longest (openTextArea) is to be first.
- The primary, secondary, and item options are to be second.
- The openTextField is to be third.
- The message the user types is to be last.

This is helpful for operators so they don't have to scroll to see what the user has typed due to very long openTextArea messages.