### PR TITLE
fix product dropdown closing when user clicks in search box

### DIFF
--- a/src/ui/components/select-dropdown/index.jsx
+++ b/src/ui/components/select-dropdown/index.jsx
@@ -65,7 +65,7 @@ class SelectDropdown extends Component {
 
 		// bounds
 		this.navigateItem = this.navigateItem.bind( this );
-		this.onContainerClick = this.onContainerClick.bind( this );
+		this.onClick = this.onClick.bind( this );
 		this.toggleDropdown = this.toggleDropdown.bind( this );
 		this.handleOutsideClick = this.handleOutsideClick.bind( this );
 		this.onSearch = this.onSearch.bind( this );
@@ -257,7 +257,7 @@ class SelectDropdown extends Component {
 					aria-controls={ 'select-submenu-' + this.state.instanceId }
 					aria-expanded={ this.state.isOpen }
 					data-tip-target={ this.props.tipTarget }
-					onClick={ this.onContainerClick }
+					onClick={ this.onClick }
 				>
 					<div
 						id={ 'select-dropdown-' + this.state.instanceId }
@@ -294,14 +294,14 @@ class SelectDropdown extends Component {
 		);
 	}
 
-	onContainerClick( event ) {
+	onClick( event ) {
 		// don't toggle the dropdown if the user clicks in the search box
 		if ( event.target === ReactDom.findDOMNode( this.refs.dropdownSearchBox ) )
 			return;
 		this.toggleDropdown();
 	}
 
-	toggleDropdown( ) {
+	toggleDropdown() {
 		this.setState( {
 			isOpen: ! this.state.isOpen,
 		} );

--- a/src/ui/components/select-dropdown/index.jsx
+++ b/src/ui/components/select-dropdown/index.jsx
@@ -65,6 +65,7 @@ class SelectDropdown extends Component {
 
 		// bounds
 		this.navigateItem = this.navigateItem.bind( this );
+		this.onContainerClick = this.onContainerClick.bind( this );
 		this.toggleDropdown = this.toggleDropdown.bind( this );
 		this.handleOutsideClick = this.handleOutsideClick.bind( this );
 		this.onSearch = this.onSearch.bind( this );
@@ -256,7 +257,7 @@ class SelectDropdown extends Component {
 					aria-controls={ 'select-submenu-' + this.state.instanceId }
 					aria-expanded={ this.state.isOpen }
 					data-tip-target={ this.props.tipTarget }
-					onClick={ this.toggleDropdown }
+					onClick={ this.onContainerClick }
 				>
 					<div
 						id={ 'select-dropdown-' + this.state.instanceId }
@@ -293,10 +294,14 @@ class SelectDropdown extends Component {
 		);
 	}
 
-	toggleDropdown( event ) {
+	onContainerClick( event ) {
 		// don't toggle the dropdown if the user clicks in the search box
 		if ( event.target === ReactDom.findDOMNode( this.refs.dropdownSearchBox ) )
 			return;
+		this.toggleDropdown();
+	}
+
+	toggleDropdown( ) {
 		this.setState( {
 			isOpen: ! this.state.isOpen,
 		} );

--- a/src/ui/components/select-dropdown/index.jsx
+++ b/src/ui/components/select-dropdown/index.jsx
@@ -280,7 +280,11 @@ class SelectDropdown extends Component {
 					>
 						{ this.props.isSearchable &&
 							this.state.isOpen && (
-								<Search onSearch={ this.onSearch } placeholder={ this.props.placeholder } />
+								<Search 
+									ref="dropdownSearchBox" 
+									onSearch={ this.onSearch } 
+									placeholder={ this.props.placeholder } 
+								/>
 							) }
 						{ this.dropdownOptions( this.state.searchValue ) }
 					</ul>
@@ -289,7 +293,10 @@ class SelectDropdown extends Component {
 		);
 	}
 
-	toggleDropdown() {
+	toggleDropdown( event ) {
+		// don't toggle the dropdown if the user clicks in the search box
+		if ( event.target === ReactDom.findDOMNode( this.refs.dropdownSearchBox ) )
+			return;
 		this.setState( {
 			isOpen: ! this.state.isOpen,
 		} );

--- a/src/ui/components/select-dropdown/test/index.js
+++ b/src/ui/components/select-dropdown/test/index.js
@@ -41,12 +41,14 @@ describe( 'index', () => {
 
 		test( 'should execute toggleDropdown when clicked', () => {
 			const originalToggleDropdown = SelectDropdown.prototype.toggleDropdown;
-			SelectDropdown.prototype.toggleDropdown = jest.fn();
+			SelectDropdown.prototype.onContainerClick = jest.fn();
 
+			const fakeEvent = prepareFakeClickEvent( { } );
 			const dropdown = shallowRenderDropdown();
-			dropdown.find( '.select-dropdown__container' ).simulate( 'click' );
+			dropdown.find( '.select-dropdown__container' ).simulate( 'click', fakeEvent );
 
-			expect( SelectDropdown.prototype.toggleDropdown.mock.calls.length ).toBe( 1 );
+
+			expect( SelectDropdown.prototype.onContainerClick.mock.calls.length ).toBe( 1 );
 			SelectDropdown.prototype.toggleDropdown = originalToggleDropdown;
 		} );
 
@@ -282,6 +284,13 @@ describe( 'index', () => {
 				preventDefault: jest.fn(),
 			};
 		}
+
+		function prepareFakeClickEvent( eventTarget ) {
+			return {
+				target: eventTarget
+			};
+		}
+
 	} );
 
 	/**

--- a/src/ui/components/select-dropdown/test/index.js
+++ b/src/ui/components/select-dropdown/test/index.js
@@ -43,7 +43,9 @@ describe( 'index', () => {
 			const originalOnClick = SelectDropdown.prototype.onClick;
 			SelectDropdown.prototype.onClick = jest.fn();
 
-			const fakeEvent = prepareFakeClickEvent( { } );
+			const fakeEvent = {
+				target: null,
+			};
 			const dropdown = shallowRenderDropdown();
 			dropdown.find( '.select-dropdown__container' ).simulate( 'click', fakeEvent );
 
@@ -61,12 +63,6 @@ describe( 'index', () => {
 			expect( SelectDropdown.prototype.navigateItem.mock.calls.length ).toBe( 1 );
 			SelectDropdown.prototype.navigateItem = originalNavigateItem;
 		} );
-
-		function prepareFakeClickEvent( eventTarget ) {
-			return {
-				target: eventTarget,
-			};
-		}
 	} );
 
 	describe( 'getInitialSelectedItem', () => {

--- a/src/ui/components/select-dropdown/test/index.js
+++ b/src/ui/components/select-dropdown/test/index.js
@@ -39,18 +39,41 @@ describe( 'index', () => {
 			expect( dropdown.find( '.select-dropdown.is-open' ).length ).toBe( 0 );
 		} );
 
-		test( 'should execute onContainerClick when clicked', () => {
-			const originalOnClick = SelectDropdown.prototype.onClick;
-			SelectDropdown.prototype.onClick = jest.fn();
+		test( 'should call toggleDropdown when clicked', () => {
+			const originalToggleDropdown = SelectDropdown.prototype.toggleDropdown;
+			SelectDropdown.prototype.toggleDropdown = jest.fn();
 
-			const fakeEvent = {
-				target: null,
-			};
-			const dropdown = shallowRenderDropdown();
-			dropdown.find( '.select-dropdown__container' ).simulate( 'click', fakeEvent );
+			const dropdown = mountDropdown();
+			dropdown.find( '.select-dropdown__container' ).simulate( 'click' );
 
-			expect( SelectDropdown.prototype.onClick.mock.calls.length ).toBe( 1 );
-			SelectDropdown.prototype.onClick = originalOnClick;
+			expect( SelectDropdown.prototype.toggleDropdown.mock.calls.length ).toBe( 1 );
+			SelectDropdown.prototype.toggleDropdown = originalToggleDropdown;
+		} );
+
+		test( 'should call toggleDropdown when the click target is not the search box (and it is opened)', () => {
+			const originalToggleDropdown = SelectDropdown.prototype.toggleDropdown;
+			SelectDropdown.prototype.toggleDropdown = jest.fn();
+
+			const dropdown = mountDropdown();
+			dropdown.find( '.select-dropdown__container' ).simulate( 'click' );
+			dropdown.setState( { isOpen: true } ); // open the search box as toggleDropdown is mocked
+			dropdown.find( 'input' ).simulate( 'click' );
+			dropdown.find( '.select-dropdown__container' ).simulate( 'click' );
+
+			expect( SelectDropdown.prototype.toggleDropdown.mock.calls.length ).toBe( 2 );
+			SelectDropdown.prototype.toggleDropdown = originalToggleDropdown;
+		} );
+
+		test( 'should not call toggleDropdown when the click target is the search box (and it is opened)', () => {
+			const originalToggleDropdown = SelectDropdown.prototype.toggleDropdown;
+			SelectDropdown.prototype.toggleDropdown = jest.fn();
+
+			const dropdown = mountDropdown();
+			dropdown.setState( { isOpen: true } ); // open the search box
+			dropdown.find( 'input' ).simulate( 'click' );
+
+			expect( SelectDropdown.prototype.toggleDropdown.mock.calls.length ).toBe( 0 );
+			SelectDropdown.prototype.toggleDropdown = originalToggleDropdown;
 		} );
 
 		test( 'should be possible to control the dropdown via keyboard', () => {

--- a/src/ui/components/select-dropdown/test/index.js
+++ b/src/ui/components/select-dropdown/test/index.js
@@ -40,15 +40,15 @@ describe( 'index', () => {
 		} );
 
 		test( 'should execute onContainerClick when clicked', () => {
-			const originalOnContainerClick = SelectDropdown.prototype.onContainerClick;
-			SelectDropdown.prototype.onContainerClick = jest.fn();
+			const originalOnClick = SelectDropdown.prototype.onClick;
+			SelectDropdown.prototype.onClick = jest.fn();
 
 			const fakeEvent = prepareFakeClickEvent( { } );
 			const dropdown = shallowRenderDropdown();
 			dropdown.find( '.select-dropdown__container' ).simulate( 'click', fakeEvent );
 
-			expect( SelectDropdown.prototype.onContainerClick.mock.calls.length ).toBe( 1 );
-			SelectDropdown.prototype.onContainerClick = originalOnContainerClick;
+			expect( SelectDropdown.prototype.onClick.mock.calls.length ).toBe( 1 );
+			SelectDropdown.prototype.onClick = originalOnClick;
 		} );
 
 		test( 'should be possible to control the dropdown via keyboard', () => {

--- a/src/ui/components/select-dropdown/test/index.js
+++ b/src/ui/components/select-dropdown/test/index.js
@@ -39,17 +39,16 @@ describe( 'index', () => {
 			expect( dropdown.find( '.select-dropdown.is-open' ).length ).toBe( 0 );
 		} );
 
-		test( 'should execute toggleDropdown when clicked', () => {
-			const originalToggleDropdown = SelectDropdown.prototype.toggleDropdown;
+		test( 'should execute onContainerClick when clicked', () => {
+			const originalOnContainerClick = SelectDropdown.prototype.onContainerClick;
 			SelectDropdown.prototype.onContainerClick = jest.fn();
 
 			const fakeEvent = prepareFakeClickEvent( { } );
 			const dropdown = shallowRenderDropdown();
 			dropdown.find( '.select-dropdown__container' ).simulate( 'click', fakeEvent );
 
-
 			expect( SelectDropdown.prototype.onContainerClick.mock.calls.length ).toBe( 1 );
-			SelectDropdown.prototype.toggleDropdown = originalToggleDropdown;
+			SelectDropdown.prototype.onContainerClick = originalOnContainerClick;
 		} );
 
 		test( 'should be possible to control the dropdown via keyboard', () => {
@@ -62,6 +61,12 @@ describe( 'index', () => {
 			expect( SelectDropdown.prototype.navigateItem.mock.calls.length ).toBe( 1 );
 			SelectDropdown.prototype.navigateItem = originalNavigateItem;
 		} );
+
+		function prepareFakeClickEvent( eventTarget ) {
+			return {
+				target: eventTarget,
+			};
+		}
 	} );
 
 	describe( 'getInitialSelectedItem', () => {
@@ -284,13 +289,6 @@ describe( 'index', () => {
 				preventDefault: jest.fn(),
 			};
 		}
-
-		function prepareFakeClickEvent( eventTarget ) {
-			return {
-				target: eventTarget
-			};
-		}
-
 	} );
 
 	/**


### PR DESCRIPTION
## Summary
The product search dropdown closes when the user clicks in the search box. This is unusual behaviour for a search box, and was [reported as an issue against WooCommerce.com](https://github.com/Automattic/woocommerce.com/issues/4597). For example, it is frustrating if you click within your search query to fix a typo!

This PR adds a check to the click handler that closes (toggles) the dropdown. If the event was triggered on the search box, it returns early, so the dropdown stays open.

## Testing
- Get HappyChat up and running (I'm new to this repo .. `npm install` `npm start` 
http://localhost:9000 !?)
- Click "What product do you need help with?" dropdown.
- Test the dropdown to make sure it's functioning correctly: 
- Click in search field => dropdown should remain open
- Edit search query, click within query text => dropdown should remain open
- Clicking an item in the dropdown should still select it and close the dropdown