### PR TITLE
Fix/bind class methods

### DIFF
--- a/src/ui/components/contact-form/index.jsx
+++ b/src/ui/components/contact-form/index.jsx
@@ -86,9 +86,19 @@ export class ContactForm extends React.Component {
 			openTextAreaValue: defaultValues.openTextArea || '',
 			defaultValues,
 		};
+
+		// bind class methods
+		this.areRequiredFieldsFilled = this.areRequiredFieldsFilled.bind( this );
 		this.handleChange = this.handleChange.bind( this );
 		this.handleItemSelected = this.handleItemSelected.bind( this );
 		this.handleOptionChange = this.handleOptionChange.bind( this );
+		this.maybeItemList = this.maybeItemList.bind( this );
+		this.maybeOpenTextArea = this.maybeOpenTextArea.bind( this );
+		this.maybeOpenTextField = this.maybeOpenTextField.bind( this );
+		this.maybePrimaryOptions = this.maybePrimaryOptions.bind( this );
+		this.maybeSecondaryOptions = this.maybeSecondaryOptions.bind( this );
+		this.maybeSubject = this.maybeSubject.bind( this );
+		this.prepareCanSubmitForm = this.prepareCanSubmitForm.bind( this );
 		this.prepareSubmitForm = this.prepareSubmitForm.bind( this );
 	}
 

--- a/src/ui/components/emojify/index.jsx
+++ b/src/ui/components/emojify/index.jsx
@@ -20,7 +20,10 @@ export default class Emojify extends PureComponent {
 
 	constructor( props ) {
 		super( props );
+
+		// bind class methods to this instance
 		this.setRef = this.setRef.bind( this );
+		this.parseEmoji = this.parseEmoji.bind( this );
 	}
 
 	componentDidMount() {

--- a/src/ui/components/form-text-input/index.jsx
+++ b/src/ui/components/form-text-input/index.jsx
@@ -20,6 +20,8 @@ export default class FormTextInput extends PureComponent {
 	constructor() {
 		super( ...arguments );
 
+		// bind class methods
+		this.focus = this.focus.bind( this );
 		this.selectOnFocus = this.selectOnFocus.bind( this );
 	}
 

--- a/src/ui/components/notices/index.jsx
+++ b/src/ui/components/notices/index.jsx
@@ -26,6 +26,13 @@ import {
  * Renders any notices about the chat session to the user
  */
 export class Notices extends Component {
+	constructor() {
+		super( ...arguments );
+
+		// bind class methods
+		this.statusNotice = this.statusNotice.bind( this );
+	}
+
 	statusNotice() {
 		const { isServerReachable, connectionStatus, chatStatus, translate } = this.props;
 

--- a/src/ui/components/select-dropdown/index.jsx
+++ b/src/ui/components/select-dropdown/index.jsx
@@ -63,12 +63,23 @@ class SelectDropdown extends Component {
 	constructor( props ) {
 		super( props );
 
-		// bounds
-		this.navigateItem = this.navigateItem.bind( this );
-		this.onClick = this.onClick.bind( this );
-		this.toggleDropdown = this.toggleDropdown.bind( this );
+		// bind methods to this instance
+		this.activateItem = this.activateItem.bind( this );
+		this.closeDropdown = this.closeDropdown.bind( this );
+		this.dropdownOptions = this.dropdownOptions.bind( this );
+		this.focusSibling = this.focusSibling.bind( this );
+		this.getInitialSelectedItem = this.getInitialSelectedItem.bind( this );
+		this.getSelectedIcon = this.getSelectedIcon.bind( this );
+		this.getSelectedText = this.getSelectedText.bind( this );
 		this.handleOutsideClick = this.handleOutsideClick.bind( this );
+		this.navigateItem = this.navigateItem.bind( this );
+		this.navigateItemByTabKey = this.navigateItemByTabKey.bind( this );
+		this.onClick = this.onClick.bind( this );
 		this.onSearch = this.onSearch.bind( this );
+		this.onSelectItem = this.onSelectItem.bind( this );
+		this.openDropdown = this.openDropdown.bind( this );
+		this.selectItem = this.selectItem.bind( this );
+		this.toggleDropdown = this.toggleDropdown.bind( this );
 
 		// state
 		const initialState = { isOpen: false, searchValue: null };

--- a/src/ui/components/select-dropdown/index.jsx
+++ b/src/ui/components/select-dropdown/index.jsx
@@ -397,7 +397,9 @@ class SelectDropdown extends Component {
 		if ( ! this.state.isOpen ) {
 			return this.openDropdown();
 		}
-		ReactDom.findDOMNode( this.refs[ 'item-' + this.focused ].refs.itemLink ).click();
+		if ( !! this.focused ) {
+			ReactDom.findDOMNode( this.refs[ 'item-' + this.focused ].refs.itemLink ).click();
+		}
 	}
 
 	focusSibling( direction ) {

--- a/src/ui/components/select-dropdown/search.jsx
+++ b/src/ui/components/select-dropdown/search.jsx
@@ -9,7 +9,10 @@ import PropTypes from 'prop-types';
 class Search extends PureComponent {
 	constructor( props ) {
 		super( props );
+
+		// bind class methods to this instance
 		this.focus = this.focus.bind( this );
+		this.getCurrentSearchValue = this.getCurrentSearchValue.bind( this );
 		this.onChange = this.onChange.bind( this );
 
 		this.state = {


### PR DESCRIPTION
Related https://github.com/Automattic/happychat-client/issues/263

It seems that it has been some collective oversight in not binding the class methods. This PR fixes that.

Context:

* Most UI components in this codebase were ported from [Calypso](https://github.com/Automattic/wp-calypso/tree/master/client/components). Like [select-dropdown](https://github.com/Automattic/wp-calypso/tree/master/client/components/select-dropdown).
* JavaScript [classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) don't bind class methods by default. Back when React used their own class system, those methods were [auto-bound](https://reactjs.org/docs/react-without-es6.html#autobinding), but now that it uses bare JavaScript classes [they aren't](https://reactjs.org/docs/handling-events.html).

Given that context,  I'm inclined to think that this was caused by the transition to newer React API which used bare JavaScript classes.

## How to test

* Get happychat running.
* Test that the following components work properly:
  * Contact form:
    * optional fields are displayed/hidden properly
    * on focusing the open text field there is no error in the console
  * emojify: send/receive a message that includes an emoji
  * select-dropdown (item list in contact form):
    * can be navigated by tab
    * hit return key on the search component doesn't return an error
