### PR TITLE
Return a cleanup function from `on` method

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -34,7 +34,10 @@ const api = {
 	open: ( { authentication, canChat, entry, entryOptions, groups, nodeId, theme, user } ) => {
 		authenticator.init( authentication );
 
-		const targetNode = createTargetNode( { nodeId, theme, groups, entryOptions } );
+		const {
+			targetNode,
+			heightInterval
+		} = createTargetNode( { nodeId, theme, groups, entryOptions } );
 
 		authenticator
 			.login()
@@ -49,6 +52,11 @@ const api = {
 				} )
 			)
 			.catch( error => renderError( targetNode, { error } ) );
+
+		// a cleanup function
+		return () => {
+			clearInterval( heightInterval )
+		}
 	},
 	/**
 	 * Method to subscribe to Happychat events, either 'availability' or 'chatStatus'.

--- a/src/index.js
+++ b/src/index.js
@@ -165,14 +165,14 @@ const createIframe = ( { nodeId, theme }, assetsLoadedHook = () => {} ) => {
 	targetNode.appendChild( spinnerLine );
 	iframeElement.contentDocument.body.appendChild( targetNode );
 
-	setInterval( () => {
+	const heightInterval = setInterval( () => {
 		const h = iframeElement.contentDocument.scrollingElement.scrollHeight;
 		if ( iframeElement.offsetHeight != h ) {
 			iframeElement.setAttribute( 'height', h + 'px' );
 		}
 	}, 200 );
 
-	return targetNode;
+	return { targetNode, heightInterval };
 };
 
 const isAnyCanChatPropFalse = ( canChat, { primaryOptions, secondaryOptions, itemList, defaultValues } ) => {


### PR DESCRIPTION
This way the height-setting interval can be cleared. Before, when the chat element was removed from the DOM, the interval threw errors in the console, as the `iframeElement` no longer existed.