### PR TITLE
build before publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "analyze-bundles": "NODE_ENV=analyze webpack -p --config webpack.standalone.config.js",
     "postinstall": "node bin/fix-local-config",
+    "prepublishOnly": "npm run build:npm",
     "start": "run-p dev:standalone",
     "dev:standalone": "run-p dev:standalone:*",
     "dev:standalone:js": "NODE_ENV=development webpack-dev-server --config webpack.standalone.config.js",


### PR DESCRIPTION
This package is now [published on npm](https://www.npmjs.com/package/happychat-client). To ensure that the npm target is built before publishing, [`prepublishOnly` npm script](https://docs.npmjs.com/misc/scripts) is added.