### PR TITLE
Add Sibyl plugin

### DIFF
--- a/src/form.scss
+++ b/src/form.scss
@@ -46,3 +46,6 @@
 @import 'ui/components/happychat-form/style';
 @import 'ui/components/contact-form/style';
 @import 'ui/css/main'; // shared typography & colors
+
+// plugins
+@import 'plugins/sibyl/style';

--- a/src/plugins/sibyl/index.jsx
+++ b/src/plugins/sibyl/index.jsx
@@ -1,0 +1,80 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+// import PropTypes from 'prop-types';
+import { debounce } from 'lodash';
+import wpcomRequest from 'wpcom-xhr-request';
+
+
+/**
+ * Internal dependencies
+ */
+import Card from 'src/ui/components/card';
+import FormLabel from 'src/ui/components/form-label';
+
+export default class Sibyl extends React.Component {
+	state = {
+		isLoading: false,
+		suggestions: [],
+	};
+
+	receiveSuggestions = (suggestions) => {
+		this.setState( {
+			isLoading: false,
+			suggestions,
+		} );
+	}
+
+	fetchSuggestions = debounce(() => {
+		this.setState( { isLoading: true } );
+
+		const query = `${this.props.subject} ${this.props.message}`.trim();
+
+		if ( ! query ) {
+			this.receiveSuggestions( [] );
+			return;
+		}
+
+		wpcomRequest({
+			apiVersion: '1.1',
+			path: '/help/qanda',
+			query: {
+				site: 'en.support.wordpress.com',
+				query,
+			},
+		}, ( error, body, headers ) => {
+			// TODO: Error handling
+			this.receiveSuggestions( Array.isArray( body ) ? body : [] );
+		} );
+	}, 400)
+
+	componentDidMount() {
+		this.fetchSuggestions();
+	}
+
+	componentDidUpdate( prevProps, prevState ) {
+		if ( prevProps.subject !== this.props.subject || prevProps.message !== this.props.message ) {
+			this.fetchSuggestions();
+		}
+	}
+
+	render() {
+		if ( ! this.state.suggestions || this.state.suggestions.length === 0 ) {
+			return null;
+		}
+
+		return (
+			<div className="sibyl">
+				<Card  className="sibyl--heading-card" compact={true}>
+					Do any of these Frequently Asked Questions help?
+				</Card>
+				{ this.state.suggestions.map( ( { id, link, title } ) => (
+					<Card key={id} className="sibyl--suggestion-card" compact={true} href={link} target="_blank">{title}</Card>
+				) ) }
+			</div>
+		);
+	}
+}

--- a/src/plugins/sibyl/index.jsx
+++ b/src/plugins/sibyl/index.jsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 // import PropTypes from 'prop-types';
-import { debounce } from 'lodash';
+import { debounce, isEmpty } from 'lodash';
 import wpcomRequest from 'wpcom-xhr-request';
 
 
@@ -17,24 +17,14 @@ import FormLabel from 'src/ui/components/form-label';
 
 export default class Sibyl extends React.Component {
 	state = {
-		isLoading: false,
 		suggestions: [],
 	};
 
-	receiveSuggestions = (suggestions) => {
-		this.setState( {
-			isLoading: false,
-			suggestions,
-		} );
-	}
-
 	fetchSuggestions = debounce(() => {
-		this.setState( { isLoading: true } );
-
 		const query = `${this.props.subject} ${this.props.message}`.trim();
 
 		if ( ! query ) {
-			this.receiveSuggestions( [] );
+			this.setState( { suggestions: [] } );
 			return;
 		}
 
@@ -46,8 +36,7 @@ export default class Sibyl extends React.Component {
 				query,
 			},
 		}, ( error, body, headers ) => {
-			// TODO: Error handling
-			this.receiveSuggestions( Array.isArray( body ) ? body : [] );
+			this.setState( { suggestions: Array.isArray( body ) ? body : [] } );
 		} );
 	}, 400)
 
@@ -62,7 +51,7 @@ export default class Sibyl extends React.Component {
 	}
 
 	render() {
-		if ( ! this.state.suggestions || this.state.suggestions.length === 0 ) {
+		if ( isEmpty( this.state.suggestions ) ) {
 			return null;
 		}
 
@@ -72,7 +61,15 @@ export default class Sibyl extends React.Component {
 					Do any of these Frequently Asked Questions help?
 				</Card>
 				{ this.state.suggestions.map( ( { id, link, title } ) => (
-					<Card key={id} className="sibyl--suggestion-card" compact={true} href={link} target="_blank">{title}</Card>
+					<Card
+						key={id}
+						className="sibyl--suggestion-card"
+						compact={true}
+						href={link}
+						target="_blank"
+					>
+						{title}
+					</Card>
 				) ) }
 			</div>
 		);

--- a/src/plugins/sibyl/style.scss
+++ b/src/plugins/sibyl/style.scss
@@ -1,0 +1,10 @@
+/** @format */
+
+.sibyl--heading-card {
+	font-size: 14px;	
+	font-weight: bold;
+}
+
+.sibyl--suggestion-card {
+	font-size: 14px;	
+}

--- a/src/plugins/sibyl/style.scss
+++ b/src/plugins/sibyl/style.scss
@@ -1,10 +1,14 @@
 /** @format */
 
-.sibyl--heading-card {
-	font-size: 14px;	
-	font-weight: bold;
+.sibyl {
+	.sibyl--heading-card, .sibyl--suggestion-card {
+		font-size: 14px;
+		padding-top: 10px;
+		padding-bottom: 10px;
+		padding-left: 14px;
+	}
 }
 
-.sibyl--suggestion-card {
-	font-size: 14px;	
+.sibyl--heading-card {	
+	font-weight: bold;
 }

--- a/src/ui/components/contact-form/index.jsx
+++ b/src/ui/components/contact-form/index.jsx
@@ -19,6 +19,7 @@ import FormButton from 'src/ui/components/form-button';
 import FormDescription from 'src/ui/components/form-description';
 import FormSelection from 'src/ui/components/form-selection';
 import SelectDropdown from 'src/ui/components/select-dropdown';
+import Sibyl from 'src/plugins/sibyl';
 
 export class ContactForm extends React.Component {
 	constructor( props ) {
@@ -362,6 +363,8 @@ export class ContactForm extends React.Component {
 	render() {
 		const { formTitle, submitFormText } = this.props;
 
+		const showSibyl = window.location.search.indexOf( 'sibyl' ) >= 0;
+
 		return (
 			<div className="contact-form">
 				<CompactCard>
@@ -387,6 +390,10 @@ export class ContactForm extends React.Component {
 					{ this.maybeOpenTextField() }
 
 					{ this.maybeOpenTextArea() }
+
+					{ showSibyl &&
+						<Sibyl subject={ this.props.showSubject ? this.state.subject : '' } message={ this.state.message } />
+					}
 
 					<FormButton
 						disabled={ ! this.prepareCanSubmitForm() }


### PR DESCRIPTION
See pbvpgB-lA-wp for context.

This PR adds a Sibyl "plugin" to the Client, so that Woo's contact page can show frequently asked questions that help our customers help themselves. There's no true plugin architecture, but this has been added with minimal bleed into the core code, and uses standard UI components. A few notes:

- It's hidden behind a "flag" — you need to add `?sibyl` to your URL to see it.
- It's hard-coded right now to pull WPCOM data, because Woo doesn't have any Sibyl Q & A seeded yet.

Both of these will turn into configurable settings in an upcoming iteration, so that consumers of the client can choose to enable Sibyl and point it at any data set they choose. (This will almost form the backbone of a very minimal plugin system).

/cc @Automattic/lighthouse — I'm not looking for code review, but wanted to give an FYI. I'm trying to keep this nice and tidy so that it's still easy to isolate when we start using the client with other consumers (whether internal or external).