### PR TITLE
Add Tracks for Sibyl and all form submissions

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
  */
 import config from 'src/config';
 import authenticator from 'src/lib/auth';
+import { recordEvent } from 'src/lib/tracks';
 
 // actions
 import {
@@ -70,6 +71,8 @@ import SpinnerLine from 'src/ui/components/spinner-line';
 const ENTRY_FORM = 'form';
 const ENTRY_CHAT = 'chat';
 
+const recordFormSubmit = supportType => recordEvent( 'happychatclient_form_submit', { support_type: supportType } );
+
 class ChatComponent {
 	constructor( props ) {
 		this.props = props;
@@ -117,6 +120,7 @@ class ChatFormComponent {
 		( warmUpMessage !== '' ) && this.props.onSendMessage( warmUpMessage );
 		openTextFieldValue && this.props.onSendMessage( openTextFieldTitle + ' ' + openTextFieldValue );
 		this.props.onSendMessage( message );
+		recordFormSubmit( 'chat' );
 	}
 
 	onEvent( formState ) {
@@ -196,6 +200,7 @@ class TicketFormComponent {
 			timeout: fallbackTicketTimeout,
 			parseResponse: fallbackTicketParseResponse,
 		} );
+		recordFormSubmit( 'ticket' );
 	}
 
 	onEvent( formState ) {

--- a/src/lib/tracks/index.js
+++ b/src/lib/tracks/index.js
@@ -1,0 +1,11 @@
+/** @format */
+
+// Asynchronously load the Tracks script if this module is used
+const script = document.createElement( 'script' );
+script.src = '//stats.wp.com/w.js';
+document.head.appendChild( script );
+window._tkq = window._tkq || [];
+
+export const recordEvent = ( name, properties = {} ) => {
+	window._tkq.push( [ 'recordEvent', name, properties ] );
+};

--- a/src/plugins/sibyl/index.jsx
+++ b/src/plugins/sibyl/index.jsx
@@ -8,20 +8,28 @@ import React from 'react';
 import { debounce, isEmpty } from 'lodash';
 import wpcomRequest from 'wpcom-xhr-request';
 
+const areSameSuggestions = ( oldSuggestions, newSuggestions ) => {
+	const oldIDs = oldSuggestions.map( suggestion => suggestion.id ).sort();
+	const newIDs = newSuggestions.map( suggestion => suggestion.id ).sort();
+	return oldIDs.toString() === newIDs.toString();
+};
 
 /**
  * Internal dependencies
  */
 import Card from 'src/ui/components/card';
 import FormLabel from 'src/ui/components/form-label';
+import { recordEvent } from 'src/lib/tracks';
 
 export default class Sibyl extends React.Component {
 	state = {
 		suggestions: [],
+		suggestionClicked: false,
 	};
 
 	fetchSuggestions = debounce(() => {
-		const query = `${this.props.subject} ${this.props.message}`.trim();
+		const { site, subject, message } = this.props;
+		const query = `${subject} ${message}`.trim();
 
 		if ( ! query ) {
 			this.setState( { suggestions: [] } );
@@ -32,15 +40,40 @@ export default class Sibyl extends React.Component {
 			apiVersion: '1.1',
 			path: '/help/qanda',
 			query: {
-				site: 'en.support.wordpress.com',
+				site,
 				query,
 			},
 		}, ( error, body, headers ) => {
-			this.setState( { suggestions: Array.isArray( body ) ? body : [] } );
+			const suggestions = Array.isArray( body ) ? body : [];
+			this.setState( {
+				suggestions,
+				suggestionClicked: this.state.suggestionClicked && areSameSuggestions( this.state.suggestions, suggestions )
+			} );
 		} );
 	}, 400)
 
+	handleSuggestionClick = suggestion => {
+		this.setState({ suggestionClicked: true });
+		recordEvent( 'happychatclient_sibyl_question_click', {
+			question_id: suggestion.id,
+			site: this.props.site
+		} );
+	}
+
+	handleFormSubmit = () => {
+		const { site } = this.props;
+
+		if ( this.state.suggestionClicked ) {
+			recordEvent( 'happychatclient_sibyl_support_after_question_click', { site } );
+		}
+
+		if ( ! isEmpty( this.state.suggestions ) ) {
+			recordEvent( 'happychatclient_sibyl_support_with_questions_showing', { site } );
+		}
+	}
+
 	componentDidMount() {
+		this.props.addFormSubmitListener( this.handleFormSubmit );
 		this.fetchSuggestions();
 	}
 
@@ -60,18 +93,22 @@ export default class Sibyl extends React.Component {
 				<Card  className="sibyl--heading-card" compact={true}>
 					Do any of these Frequently Asked Questions help?
 				</Card>
-				{ this.state.suggestions.map( ( { id, link, title } ) => (
-					<Card
+				{ this.state.suggestions.map( ( suggestion ) => {
+					const { id, link, title } = suggestion;
+					return <Card
 						key={id}
 						className="sibyl--suggestion-card"
 						compact={true}
 						href={link}
 						target="_blank"
-					>
-						{title}
-					</Card>
-				) ) }
+						onClick={() => this.handleSuggestionClick( suggestion )}
+						children={title}
+					/>;
+				} ) }
 			</div>
 		);
 	}
 }
+
+// TODO Proptypes?
+

--- a/src/ui/components/contact-form/index.jsx
+++ b/src/ui/components/contact-form/index.jsx
@@ -67,6 +67,7 @@ export class ContactForm extends React.Component {
 			openTextAreaTitle,
 			openTextAreaValue: defaultValues.openTextArea || '',
 			defaultValues,
+			formSubmitListeners: [],
 		};
 
 		// bind class methods
@@ -122,6 +123,10 @@ export class ContactForm extends React.Component {
 				message,
 			} );
 		}
+	}
+
+	addFormSubmitListener = func => {
+		this.setState( { formSubmitListeners: this.state.formSubmitListeners.concat(func) } );
 	}
 
 	handleChange( e ) {
@@ -222,6 +227,7 @@ export class ContactForm extends React.Component {
 	}
 
 	prepareSubmitForm() {
+		this.state.formSubmitListeners.forEach( f => f() );
 		this.props.submitForm( this.state );
 	}
 
@@ -392,7 +398,12 @@ export class ContactForm extends React.Component {
 					{ this.maybeOpenTextArea() }
 
 					{ showSibyl &&
-						<Sibyl subject={ this.props.showSubject ? this.state.subject : '' } message={ this.state.message } />
+						<Sibyl
+							subject={ this.props.showSubject ? this.state.subject : '' }
+							message={ this.state.message }
+							site="en.support.wordpress.com"
+							addFormSubmitListener={this.addFormSubmitListener}
+						/>
 					}
 
 					<FormButton


### PR DESCRIPTION
This adds Tracks events to track Sibyl performance and generally how many form submissions there are.

- `happychatclient_form_submit` — Any time the form is submitted, with `support_type` reflecting `chat` or `ticket`
- `happychatclient_sibyl_question_click` — Same as the Calypso equivalent, tracks every time the user clicks one of the suggested questions
- `happychatclient_sibyl_support_after_question_click` — Same as the Calypso equivalent, tracks any time the customer sees new questions, clicks at least one of them, but still chooses to open a chat/ticket
- `happychatclient_sibyl_support_with_questions_showing` — New event, tracks how often new questions were shown to the user, and they opened a chat/ticket without clicking any of them. This gives us another view into Sibyl's performance.

Note: Eventually, at the lib level (probably) we'll want to track each consumer of the Client separately (like by some identifier they send us). But since only Woo is using this right now, and there's no such identifier to grab onto, I'm ignoring that for now.

### How to test
- `npm start` to fire up the standalone client
- Go to `http://localhost:9000/?sibyl`
- Open your Network inspector and filter on `t.gif` which is the pixel fired when Tracks events are recorded

#### Verify that form submissions are tracked
- Without being signed into Happy Chat, open the form
- Fill it out and click "Create ticket"
- You should see `t.gif` fire a `happychatclient_form_submit` event with `support_type=ticket`
- Now sign in and go Green in the Woo product at https://hud-staging.happychat.io/
- Refresh the standalone client page
- Fill out the form and click "Start chat"
- You should see `t.gif` fire a `happychatclient_form_submit` event with `support_type=chat`

#### Verify that suggestion clicks are tracked
- Add info to the Subject and Message fields like "CSS Domain" to trigger Sibyl suggestions
- Click one of the suggestions
- You should see `t.gif` fire a `happychatclient_sibyl_question_click` event

#### Verify that submitting after clicking is tracked
- Add info to the Subject and Message fields like "CSS Domain" to trigger Sibyl suggestions
- Click one of the suggestions
- Submit the form
- You should see `t.gif` fire a `happychatclient_sibyl_support_after_question_click` event
- You should also see `t.gif` fire a `happychatclient_sibyl_support_with_questions_showing` event

#### Verify that new questions reset the click counter
- Add info to the Subject and Message fields like "CSS Domain" to trigger Sibyl suggestions
- Click one of the suggestions
- Now erase that info and add new info like "Plugins"
- You should see new suggestions — do not click them!
- Submit the form
- You should *not** see `t.gif` fire a `happychatclient_sibyl_support_after_question_click` event