### PR TITLE
Make Sibyl plugin configurable

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -7,6 +7,7 @@
 	* entryOptions
 	* groups
 	* nodeId
+	* plugins
 	* theme
 * Examples
 	* Default
@@ -31,6 +32,7 @@ with the following top-level properties:
 | `entryOptions` | object | Optional | `{}` | Configures Happychat entry points. See details below. |
 | `groups` | array | Optional | `[WP.com]` | What group the chat session should be routed to. Valid values are `WP.com`, `woo`, and `jpop`. |
 | `nodeId` | string | Mandatory | `null` | The id of the HTMLNode where Happychat will be rendered. |
+| `plugins` | object | Optional | `{}` | Configuration for the plugins you want to activate. See details below.  |
 | `theme` | string | Optional | `null` | The theme to use. Valid values are the group names. |
 | `cssDir` | string | Optional | `null` | The URL prefix for the folder that contains the happychat CSS files (allows serving from other than widgets.wp.com) |
 
@@ -225,6 +227,22 @@ Currently, Happychat can connect customers to any of these groups:
 ### nodeId
 
 The Happychat library will create an iframe within the HTML node provided by this id.
+
+### plugins
+
+_Note: This is an experimental feature!_
+
+When you want to activate a plugin, send a configuration object for the plugin keyed on the plugin's name. For example:
+
+```
+plugins: {
+	sibyl: {
+		site: "en.support.wordpress.com",
+	}
+}
+```
+
+This will activate the Sibyl plugin, and the plugin will be passed the `site` configuration value. Each plugin has its own configuration options.
 
 ### theme
 

--- a/src/api.js
+++ b/src/api.js
@@ -31,7 +31,7 @@ const api = {
 	 * @param {string} nodeId Mandatory. HTML Node id where Happychat will be rendered.
 	 * @param {Object} user Optional. Customer information.
 	 */
-	open: ( { authentication, canChat, entry, entryOptions, groups, nodeId, theme, user } ) => {
+	open: ( { authentication, canChat, entry, entryOptions, groups, nodeId, plugins, theme, user } ) => {
 		authenticator.init( authentication );
 
 		const targetNode = createTargetNode( { nodeId, theme, groups, entryOptions } );
@@ -46,6 +46,7 @@ const api = {
 					groups,
 					entry,
 					entryOptions,
+					plugins,
 				} )
 			)
 			.catch( error => renderError( targetNode, { error } ) );

--- a/src/form.js
+++ b/src/form.js
@@ -149,6 +149,7 @@ class ChatFormComponent {
 				defaultValues,
 				buttonText: { chat: buttonTextChat },
 			},
+			plugins,
 		} = this.props;
 		return (
 			<ContactForm
@@ -165,6 +166,7 @@ class ChatFormComponent {
 				submitForm={ this.submitForm }
 				submitFormText={ buttonTextChat }
 				onEvent={ this.onEvent }
+				plugins={ plugins }
 			/>
 		);
 	}
@@ -246,6 +248,7 @@ class TicketFormComponent {
 				buttonText: { ticket: buttonTextTicket },
 				defaultValues: initValues, // initial default values: to be used on fallback success
 			},
+			plugins,
 		} = this.props;
 
 		let form;
@@ -314,6 +317,7 @@ class TicketFormComponent {
 						submitForm={ this.submitForm }
 						submitFormText={ buttonTextTicket }
 						onEvent={ this.onEvent }
+						plugins={ plugins }
 					/>
 				);
 		}
@@ -392,6 +396,7 @@ Form.propTypes = {
 	canChat: PropTypes.bool,
 	entry: PropTypes.string,
 	entryOptions: PropTypes.object,
+	plugins: PropTypes.object,
 };
 
 // Whether URL should open a new tab or not.

--- a/src/index.js
+++ b/src/index.js
@@ -197,6 +197,7 @@ export const renderHappychat = (
 		canChat = true,
 		entry = ENTRY_FORM,
 		entryOptions = {},
+		plugins = {},
 	}
 ) => {
 	store.dispatch(
@@ -219,7 +220,7 @@ export const renderHappychat = (
 
 	ReactDOM.render(
 		<Provider store={ store }>
-			<Happychat entry={ entry } canChat={ canChat } entryOptions={ entryOptions } />
+			<Happychat entry={ entry } canChat={ canChat } entryOptions={ entryOptions } plugins={ plugins } />
 		</Provider>,
 		targetNode
 	);

--- a/src/plugins/sibyl/index.jsx
+++ b/src/plugins/sibyl/index.jsx
@@ -28,7 +28,7 @@ export default class Sibyl extends React.Component {
 	};
 
 	fetchSuggestions = debounce(() => {
-		const { site, subject, message } = this.props;
+		const { config: { site }, subject, message } = this.props;
 		const query = `${subject} ${message}`.trim();
 
 		if ( ! query ) {
@@ -56,12 +56,12 @@ export default class Sibyl extends React.Component {
 		this.setState({ suggestionClicked: true });
 		recordEvent( 'happychatclient_sibyl_question_click', {
 			question_id: suggestion.id,
-			site: this.props.site
+			site: this.props.config.site
 		} );
 	}
 
 	handleFormSubmit = () => {
-		const { site } = this.props;
+		const { config: { site } } = this.props;
 
 		if ( this.state.suggestionClicked ) {
 			recordEvent( 'happychatclient_sibyl_support_after_question_click', { site } );

--- a/src/ui/components/contact-form/index.jsx
+++ b/src/ui/components/contact-form/index.jsx
@@ -367,9 +367,7 @@ export class ContactForm extends React.Component {
 	}
 
 	render() {
-		const { formTitle, submitFormText } = this.props;
-
-		const showSibyl = window.location.search.indexOf( 'sibyl' ) >= 0;
+		const { formTitle, submitFormText, plugins } = this.props;
 
 		return (
 			<div className="contact-form">
@@ -397,12 +395,12 @@ export class ContactForm extends React.Component {
 
 					{ this.maybeOpenTextArea() }
 
-					{ showSibyl &&
+					{ plugins.hasOwnProperty( 'sibyl' ) &&
 						<Sibyl
 							subject={ this.props.showSubject ? this.state.subject : '' }
 							message={ this.state.message }
-							site="en.support.wordpress.com"
 							addFormSubmitListener={this.addFormSubmitListener}
+							config={ plugins[ 'sibyl' ] }
 						/>
 					}
 
@@ -457,4 +455,5 @@ ContactForm.defaultProps = {
 	submitForm: () => {},
 	submitFormText: 'Send',
 	onEvent: () => {},
+	plugins: {},
 };

--- a/targets/standalone/example.html
+++ b/targets/standalone/example.html
@@ -76,6 +76,11 @@
 							'X-Test-Header-2': 'test 2'
 						}
 					}
+				},
+				plugins: {
+					sibyl: {
+						site: 'en.support.wordpress.com'
+					}
 				}
 			});
 		});

--- a/targets/wordpress/plugin/assets/client-happychat-init.js
+++ b/targets/wordpress/plugin/assets/client-happychat-init.js
@@ -70,6 +70,7 @@
 			canChat: toBoolean( happychatSettings.canChat ),
 			entry: happychatSettings.entry,
 			entryOptions: parseOptions( happychatSettings.entryOptions ),
+			plugins: happychatSettings.plugins,
 			theme: happychatSettings.theme,
 		} );
 } )();

--- a/targets/wordpress/plugin/class-happychat-client.php
+++ b/targets/wordpress/plugin/class-happychat-client.php
@@ -89,6 +89,7 @@ class Happychat_Client {
 			'accessToken'  => null,
 			'entry'        => 'ENTRY_FORM',
 			'entryOptions' => [],
+			'plugins'      => [],
 			'groups'       => [ get_option( 'happychat_user_group' ) ],
 			'canChat'      => 'true',
 			'nodeId'       => 'happychat-form',


### PR DESCRIPTION
Creates a very rudimentary system for consumers of the Client to decide which plugins to enable, and how to pass configuration options down. See changes in `docs/API.md` for full description.

### How to test

- Open the standalone page and type words like "CSS domains" into the message box
- It should show Sibyl suggestions from the WPCOM data source
- Now modify `targets/standalone/example.html` and remove `sibyl` from the `plugins` object
- Refresh the standalone page and type words like "CSS domains" into the message box
- You shouldn't see any Sibyl suggestions appear