### PR TITLE
Update Woo colors

### DIFF
--- a/src/ui/css/shared/_colors.scss
+++ b/src/ui/css/shared/_colors.scss
@@ -32,13 +32,13 @@ $green-jetpack: #00be28;
 // See https://woocommerce.com/style-guide/#sg-palette for more info.
 
 // Woo Accents
-$purple-woo: #96588a;
-$green-woo: #71b02f;
+$purple-woo: #9a69c7;
+$green-woo: #029172;
 
 // Woo Neutrals
-$gray-dark-woo: #3c3c3c;
-$gray-light-woo: #f7f7f7;
-$gray-woo: darken(#e6e6e6, 30%);
+$gray-dark-woo: #2c3337;
+$gray-light-woo: #f6f7f7;
+$gray-woo: darken(#dcdcde, 30%);
 
 // Alerts
 $alert-yellow: #f0b849;


### PR DESCRIPTION
### Description

As a part of the [WooCommerce.com color update](https://woosupport.wordpress.com/2020/05/28/woocommerce-com-color-update/) we need to update the Happychat client colors.

### Testing instructions

- Check out this branch
- Replace `jpop` with `woo` 
https://github.com/Automattic/happychat-client/blob/f9af4ecc3b0baf57340c6dcbc98a6d9aa54ffedb/targets/standalone/example.html#L29
- Replace the `css_url` value with `http://localhost:9000/`
https://github.com/Automattic/happychat-client/blob/ddae4671643ae2bdc2fa9e1e85f5d03e8aa59991/src/config/development.json#L2 
- Run the local env `npm install && npm start`
- Open http://localhost:9000/ and see the updated colors
