### PR TITLE
Tweaked Woo colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "happychat-client",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happychat-client",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "",
   "main": "./targets/npm/api.js",
   "keywords": [],

--- a/src/ui/css/shared/_colors.scss
+++ b/src/ui/css/shared/_colors.scss
@@ -32,7 +32,7 @@ $green-jetpack: #00be28;
 // See https://woocommerce.com/style-guide/#sg-palette for more info.
 
 // Woo Accents
-$purple-woo: #9a69c7;
+$purple-woo: #7f54b3;
 $green-woo: #029172;
 
 // Woo Neutrals

--- a/targets/wordpress/plugin/class-happychat-admin.php
+++ b/targets/wordpress/plugin/class-happychat-admin.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Happychat_Admin {
 	private static $_instance = null;
-	const VERSION             = '0.0.4-dev';
+	const VERSION             = '0.0.5-dev';
 
 	/**
 	 * Create instance of class

--- a/targets/wordpress/plugin/class-happychat-client.php
+++ b/targets/wordpress/plugin/class-happychat-client.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Happychat_Client {
 	private static $_instance = null;
-	const VERSION             = '0.0.4-dev';
+	const VERSION             = '0.0.5-dev';
 
 	/**
 	* Create instance of class

--- a/targets/wordpress/plugin/happychat.php
+++ b/targets/wordpress/plugin/happychat.php
@@ -3,7 +3,7 @@
 * Plugin Name: Happychat
 * Plugin URI: https://github.com/Automattic/happychat-client
 * Description: Adds Happychat as a shortcode, allowing customers to get support via real time chat.
-* Version: 0.0.4-dev
+* Version: 0.0.5-dev
 * Author: Automattic
 * Author URI: http://automattic.com
 *


### PR DESCRIPTION
Following #296, @bero applied a change to the Woo colors used in HappyChat (#297). Soon after, we [discovered](https://github.com/Automattic/woocommerce.com/issues/7777) that the colors we'd switched too weren't _exactly_ right and [had to fix them](https://github.com/Automattic/woocommerce.com/pull/7779).

This tiny change replicates that fix into HappyChat.

### Testing instructions

- Check out this branch
- Replace `jpop` with `woo` in targets/standalone/example.html
https://github.com/Automattic/happychat-client/blob/23eb2e8d4ca3658c2368f397eecd5a3201c0ac46/targets/standalone/example.html#L29
- Replace the `css_url` value with `http://localhost:9000/` in src/config/development.json
https://github.com/Automattic/happychat-client/blob/23eb2e8d4ca3658c2368f397eecd5a3201c0ac46/src/config/development.json#L2 
- Run the local env `npm install && npm start`
- Open http://localhost:9000/ and see the updated colors
