### PR TITLE
Sibyl: Add a few trackers

### DIFF
--- a/src/plugins/sibyl/index.jsx
+++ b/src/plugins/sibyl/index.jsx
@@ -76,7 +76,12 @@ export default class Sibyl extends React.Component {
 			recordEvent( 'happychatclient_sibyl_support_after_question_click', { site } );
 		}
 
-		if ( ! isEmpty( this.state.suggestions ) ) {
+		if ( isEmpty( this.state.suggestions ) ) {
+			recordEvent( 'happychatclient_sibyl_support_without_matching_questions', {
+				site,
+				query: this.getSearchQuery(),
+			} );
+		} else {
 			recordEvent( 'happychatclient_sibyl_support_with_questions_showing', {
 				site,
 				query: this.getSearchQuery(),

--- a/src/plugins/sibyl/index.jsx
+++ b/src/plugins/sibyl/index.jsx
@@ -27,9 +27,11 @@ export default class Sibyl extends React.Component {
 		suggestionClicked: false,
 	};
 
+	getSearchQuery = () => `${this.props.subject} ${this.props.message}`.trim();
+
 	fetchSuggestions = debounce(() => {
 		const { config: { site }, subject, message } = this.props;
-		const query = `${subject} ${message}`.trim();
+		const query = this.getSearchQuery();
 
 		if ( ! query ) {
 			this.setState( { suggestions: [] } );
@@ -53,6 +55,13 @@ export default class Sibyl extends React.Component {
 	}, 400)
 
 	handleSuggestionClick = suggestion => {
+		if ( ! this.state.suggestionClicked ) {
+			recordEvent( 'happychatclient_sibyl_first_question_click', {
+				question_id: suggestion.id,
+				site: this.props.config.site
+			} );
+		}
+
 		this.setState({ suggestionClicked: true });
 		recordEvent( 'happychatclient_sibyl_question_click', {
 			question_id: suggestion.id,
@@ -68,7 +77,11 @@ export default class Sibyl extends React.Component {
 		}
 
 		if ( ! isEmpty( this.state.suggestions ) ) {
-			recordEvent( 'happychatclient_sibyl_support_with_questions_showing', { site } );
+			recordEvent( 'happychatclient_sibyl_support_with_questions_showing', {
+				site,
+				query: this.getSearchQuery(),
+				suggestions: this.state.suggestions.map( ({id, title}) => `${id} - ${title}` ).join(' / '),
+			} );
 		}
 	}
 
@@ -111,4 +124,3 @@ export default class Sibyl extends React.Component {
 }
 
 // TODO Proptypes?
-


### PR DESCRIPTION
This adds Tracks info on Sibyl:

- New event that fires on the first click (so we have a click stat that dedupes multi-clicks, helps us tell how often people click more than once, and also brings us closer to understanding actual deflection performance)

- New event that fires when the form is submitted with no suggestions showing (to spot-check what kind of questions have no matches — opportunity for us to improve)

- Add query and suggestions when submitted with suggestions showing