### PR TITLE
Chat overflow: Add signifier to fallback tickets

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -193,12 +193,17 @@ class TicketFormComponent {
 			fallbackTicketHeaders,
 			fallbackTicketTimeout,
 			fallbackTicketParseResponse,
+			isChatAvailable,
+			isUserEligibleForChat,
 		} = this.props;
 		this.props.onRequestFallbackTicket( {
 			url: fallbackTicketUrl,
 			method: fallbackTicketMethod,
 			headers: fallbackTicketHeaders,
-			payload: formState,
+			payload: {
+				...formState,
+				isChatOverflow: ( isUserEligibleForChat && ! isChatAvailable ),
+			},
 			timeout: fallbackTicketTimeout,
 			parseResponse: fallbackTicketParseResponse,
 		} );


### PR DESCRIPTION
It's useful when a ticket is created, to know if it was because `canChat` was false somewhere along the line (e.g. this interaction would have been a ticket regardless) or because there was no chat availability (e.g. this interaction should have been a chat, but it overflowed into a ticket).

This PR sends the `isChatOverflow` boolean with fallback ticket API requests, which will be `true` if the user could chat but chat was not available, and `false` if the user was simply not allowed to chat.