### PR TITLE
Add happychatUrl option to API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -65,6 +65,20 @@ How to configure authentication via proxy iframe:
 		},
 	} );
 
+#### Connecting to alternate socket servers
+
+If you want to connect to another socket server (like a staging or local) you can pass `authentication.options.happychatUrl`, for example:
+
+	Happychat.open( {
+		authentication: {
+			type: ...,
+			options: {
+				happychatUrl: 'http://localhost:3232/customer',
+				...
+			},
+		},
+	} );
+
 ### canChat
 
 Whether the user can be offered chat or not. If this property is false, no chat will be offered. This can also be configured per option, see `entryOptions` below.

--- a/src/api.js
+++ b/src/api.js
@@ -20,6 +20,7 @@ const api = {
 	 * @param {Object} authentication Mandatory. Set of authentication options
 	 * @param {string} authentication.type Mandatory. Type of authentication strategy used
 	 * @param {Object} authentication.options Optional. Authentication options
+	 * @param {Object} authentication.options.happychatUrl Optional. Alternate socket server URL
 	 * @param {Object} authentication.options.token Optional. WP.com oAuth access token to be used
 	 * @param {Object} authentication.options.proxy Optional. WP.com proxy object to be used
 	 * @param {boolean} canChat Optional. Whether the user can be offered chat. True by default.

--- a/src/lib/auth/strategies/wpcom/index.js
+++ b/src/lib/auth/strategies/wpcom/index.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import { get } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -66,7 +67,7 @@ export class WPcomStrategy extends BaseStrategy {
 		 */
 		return () => {
 			let geoLocation;
-			const url = config( 'happychat_url' );
+			const url = get( this, 'options.happychatUrl', config( 'happychat_url' ) );
 
 			const user = getUser( state );
 			const skills = getUserSkills( state );


### PR DESCRIPTION
Enables users of the API to connect to alternate socket servers. Useful for connecting to local or staging servers from within development environments of hosts that implement `happychat-client`.