### PR TITLE
Add option to tie form fields directly to Chat Custom Fields

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -104,14 +104,19 @@ The `entryOptions` property allows for configuring the text and behavior or Happ
 | `formTitle` | string | `Contact form` | Title of form. |
 | `primaryOptionsTitle` | string | `How can we help` | Title of primary options menu. |
 | `primaryOptions` | array | `[]` | Contains the options to be shown in the primary menu. They'll be rendered either as a segmented control or a dropdown depending on the window width. If not provided, this section won't be shown. |
+| `primaryOptionsCustomFieldKey` | string | `null` | Add a key to save the result as a Custom Field on the chat. |
 | `secondaryOptionsTitle` | string | `Any more info you want to share?` | Title of secondary options menu. |
 | `secondaryOptions` | array | `[]` | Contains the options to be shown in the secondary menu. They'll be rendered either as a segmented control or a dropdown depending on the window width. If not provided, this section won't be shown. |
+| `secondaryOptionsCustomFieldKey` | string | `null` | Add a key to save the result as a Custom Field on the chat. |
 | `itemListTitle` | string | `Which product do you need help with?` | Title of item list menu. |
 | `itemList` | array | `[]` | Contains the options to be shown in the item list menu. They'll be rendered as a dropdown. If not provided, this section won't be shown. |
+| `itemListCustomFieldKey` | string | `null` | Add a key to save the result as a Custom Field on the chat. |
 | `openTextFieldTitle` | string | `What is the URL of your site?` | Title for the textfield component. |
 | `openTextField` | object | `{}` | Contains conditions under which to show the text field. |
+| `openTextFieldCustomFieldKey` | string | `null` | Add a key to save the result as a Custom Field on the chat. |
 | `openTextAreaTitle` | string | `Any more info you want to share?` | Title for the textarea component. |
 | `openTextArea` | object | `{}` | Contains conditions under which to show the text area.|
+| `openTextAreaCustomFieldKey` | string | `null` | Add a key to save the result as a Custom Field on the chat. |
 | `buttonText` | object | `{'ticket': "Send a ticket", 'chat': "Chat with us"}` | Contains the text to show for the two allowed states: offer ticket or chat. |
 | `defaultValues` | object | `{}` | Configures default values for the form. |
 | `fallbackTicket` | object | `{}` | Configures a default route that Happychat will use to offer ticket support as a fallback when chat is not available. |

--- a/src/form.js
+++ b/src/form.js
@@ -113,16 +113,53 @@ class ChatFormComponent {
 		openTextAreaTitle,
 		openTextAreaValue,
 	} ) {
+		const {
+			primaryOptionsCustomFieldKey,
+			secondaryOptionsCustomFieldKey,
+			itemListCustomFieldKey,
+			openTextFieldCustomFieldKey,
+			openTextAreaCustomFieldKey,
+		} = this.props.entryOptions;
+
+		const customFields = {};
+
 		this.props.onOpenChat();
-		this.props.onSetChatCustomFields( { channel: this.props.userGroups ? this.props.userGroups[0] : null } );
-		openTextAreaValue && this.props.onSendMessage( openTextAreaTitle + '\n ' + openTextAreaValue );
-		let warmUpMessage = primarySelected.label ? ( primaryOptionsTitle + ' ' + primarySelected.label + '\n' ) : '';
-		warmUpMessage = warmUpMessage + ( secondarySelected.label ? ( secondaryOptionsTitle + ' ' + secondarySelected.label + '\n' ) : '' );
-		warmUpMessage = warmUpMessage + ( itemSelected.label ? ( itemListTitle + ' ' + itemSelected.label + '\n' ) : '' );
+
+		if ( openTextAreaValue ) {
+			this.props.onSendMessage( openTextAreaTitle + '\n ' + openTextAreaValue );
+			openTextAreaCustomFieldKey && ( customFields[ openTextAreaCustomFieldKey ] = openTextAreaValue );
+		}
+
+		let warmUpMessage = '';
+
+		if ( primarySelected.label ) {
+			warmUpMessage += primaryOptionsTitle + ' ' + primarySelected.label + '\n';
+			primaryOptionsCustomFieldKey && ( customFields[ primaryOptionsCustomFieldKey ] = primarySelected.value );
+		}
+
+		if ( secondarySelected.label ) {
+			warmUpMessage += secondaryOptionsTitle + ' ' + secondarySelected.label + '\n';
+			secondaryOptionsCustomFieldKey && ( customFields[ secondaryOptionsCustomFieldKey ] = secondarySelected.value );
+		}
+
+		if ( itemSelected.label ) {
+			warmUpMessage += itemListTitle + ' ' + itemSelected.label + '\n';
+			itemListCustomFieldKey && ( customFields[ itemListCustomFieldKey ] = itemSelected.value );
+		}
+
 		( warmUpMessage !== '' ) && this.props.onSendMessage( warmUpMessage );
-		openTextFieldValue && this.props.onSendMessage( openTextFieldTitle + ' ' + openTextFieldValue );
+
+		if ( openTextFieldValue ) {
+			this.props.onSendMessage( openTextFieldTitle + ' ' + openTextFieldValue );
+			openTextFieldCustomFieldKey && ( customFields[ openTextFieldCustomFieldKey ] = openTextFieldValue );
+		}
+
 		this.props.onSendMessage( message );
 		recordFormSubmit( 'chat' );
+
+		if ( Object.keys( customFields ).length > 0 ) {
+			this.props.onSetChatCustomFields( customFields );
+		}
 	}
 
 	onEvent( formState ) {

--- a/targets/standalone/example.html
+++ b/targets/standalone/example.html
@@ -37,28 +37,33 @@
 						{ value: 'account', label: 'Help with my account', },
 						{ value: 'broken', label: 'Something is broken' },
 					],
+					primaryOptionsCustomFieldKey: 'devClientPrimary',
 					secondaryOptions: [
 						{ value: 'config', label: 'Help configuring', primary: ['account'], description: ['A secondary description.'] },
 						{ value: 'order', label: 'Help with an order', primary: ['account'], },
 						{ value: 'themes', label: 'Themes', primary: ['before-buy', 'broken'], description: ['Themes are awesome.'] },
 						{ value: 'plugins', label: 'Plugins', primary: ['before-buy', 'broken'], description: ['Plugins are awesome.'] },
 					],
+					secondaryOptionsCustomFieldKey: 'devClientSecondary',
 					itemList: [
 						{ value: '2010', label: '2010 theme', primary: ['before-buy'], secondary: ['themes'], description: ['An item description.'] },
 						{ value: '2011', label: '2011 theme', primary: ['before-buy'], secondary: ['themes'] },
 						{ value: 'jp', label: 'Jetpack', secondary: ['plugins'], description: ['An awesome plugin.'] },
 						{ value: 'wc', label: 'WooCommerce', secondary: ['plugins'], canChat: false },
 					],
+					itemListCustomFieldKey: 'devClientItemList',
 					openTextField: {
 						primary: ['before-buy'],
 						secondary: ['themes'],
 						isRequired: true,
 					},
+					openTextFieldCustomFieldKey: 'devClientTextField',
 					openTextArea: {
 						primary: ['before-buy'],
 						secondary: ['themes'],
 						isRequired: true
 					},
+					openTextAreaCustomFieldKey: 'devClientTextArea',
 					buttonText: {
 						ticket: 'Create ticket',
 						chat: 'Start chat',


### PR DESCRIPTION
Adds new `entryOptions` that let you specify a Custom Field key for any of the form fields. When one of these is set, if the corresponding field is filled out, the value will be set as a Custom Field with the specified key once the chat starts.

### How to test

Load the standalone sample locally, fill out all the fields, and open a chat. In the HUD you should see a Custom Fields entry for each of the form fields (other than the core message itself).