### PR TITLE
Move Sibyl up to below the main body field

### DIFF
--- a/src/plugins/sibyl/style.scss
+++ b/src/plugins/sibyl/style.scss
@@ -1,6 +1,7 @@
 /** @format */
 
 .sibyl {
+	margin-bottom: 36px;
 	.sibyl--heading-card, .sibyl--suggestion-card {
 		font-size: 14px;
 		padding-top: 10px;

--- a/src/ui/components/contact-form/index.jsx
+++ b/src/ui/components/contact-form/index.jsx
@@ -391,10 +391,6 @@ export class ContactForm extends React.Component {
 						onChange={ this.handleChange }
 					/>
 
-					{ this.maybeOpenTextField() }
-
-					{ this.maybeOpenTextArea() }
-
 					{ plugins.hasOwnProperty( 'sibyl' ) &&
 						<Sibyl
 							subject={ this.props.showSubject ? this.state.subject : '' }
@@ -403,6 +399,10 @@ export class ContactForm extends React.Component {
 							config={ plugins[ 'sibyl' ] }
 						/>
 					}
+
+					{ this.maybeOpenTextField() }
+
+					{ this.maybeOpenTextArea() }
 
 					<FormButton
 						disabled={ ! this.prepareCanSubmitForm() }


### PR DESCRIPTION
This is in preparation for SSR Troubleshooting (#314 / pbvpgB-13I-p2).

That project will check the SSR for troubleshooting flags and show them. It makes sense for that UI to live just after the SSR textarea (at the bottom of the form). However, that's where Sibyl goes right now, and it's pretty noisy to have them both in that space.

So while I'm working on the SSR Troubleshooting code, I wanted to experiment with moving Sibyl closer to the inputs that trigger it to fetch and display. If the performance over the following ~week are about the same, we can keep it here for now.

<img width="1063" alt="Screen Shot 2021-04-26 at 10 31 20 PM" src="https://user-images.githubusercontent.com/518059/116181144-b7699580-a6df-11eb-89ea-7f746ae24ea3.png">

(On the "Help with my extensions" form Sibyl will move, on the other forms it actually will be in the same place because the bottom two form fields don't exist.)

I wonder a bit if this will _increase_ Sibyl requests, because maybe customers will notice that the text they type gives new results, and play with it in real-time almost as a "search engine". In any case, I'll watch the metrics and if it totally tanks, revert.