### PR TITLE
Open chat immediately if assigned

### DIFF
--- a/src/lib/tracks/index.js
+++ b/src/lib/tracks/index.js
@@ -1,12 +1,19 @@
 /** @format */
 
+let enabled = ( typeof document !== 'undefined' && typeof window !== 'undefined' );
+
 // Asynchronously load the Tracks script if this module is used
-const script = document.createElement( 'script' );
-script.src = '//stats.wp.com/w.js';
-document.head.appendChild( script );
-window._tkq = window._tkq || [];
+if ( enabled ) {
+	const script = document.createElement( 'script' );
+	script.src = '//stats.wp.com/w.js';
+	document.head.appendChild( script );
+	window._tkq = window._tkq || [];
+}
 
 export const recordEvent = ( name, properties = {} ) => {
+	if ( ! enabled ) {
+		return;
+	}
 	const propertiesWithDefaults = {
 		...properties,
 		happychatclient_version: require('/package.json').version,


### PR DESCRIPTION
When the form initializes and handshakes with Happy Chat, the chat's status is sent back. If that initial status is `assigned` it means the user has a chat-in-progress and either refreshed the tab or opened the form in another tab. Either way, we should bypass the form in this case and load straight to the chat UI.

This PR makes that change.

I suspect that in Woo, it's relatively frequent that a user in chat refreshes or navigates away and comes back, and then they have to re-fill the entire form all over again. This should massively help with that.

Fixes https://github.com/Automattic/happychat/issues/1649
