### PR TITLE
Send event messages when customers interact with links in messages

### DIFF
--- a/src/ui/components/timeline/index.jsx
+++ b/src/ui/components/timeline/index.jsx
@@ -31,8 +31,8 @@ const debug = debugFactory( 'happychat-client:ui:timeline' );
 
 const linksNotEmpty = ( { links } ) => ! isEmpty( links );
 
-const messageParagraph = ( { message, isEdited, key, twemojiUrl } ) => (
-	<p key={ key }>
+const messageParagraph = ( { message, messageId, isEdited, twemojiUrl } ) => (
+	<p key={ messageId }>
 		<Emojify twemojiUrl={ twemojiUrl }>{ message }</Emojify>
 		{isEdited && <small className="timeline__edited-flag">(edited)</small>}
 	</p>
@@ -75,7 +75,6 @@ class MessageLink extends React.Component {
 				target={ target }
 				onClick={ this.handleClick }
 				onMouseDown={ this.handleMouseDown }
-				key={key}
 			>
 				{ children }
 			</a>

--- a/src/ui/components/timeline/index.jsx
+++ b/src/ui/components/timeline/index.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -22,6 +23,8 @@ import { first, when, forEach } from './functional';
 import autoscroll from './autoscroll';
 import { addSchemeIfMissing, setUrlScheme } from './url';
 import { recordEvent } from 'src/lib/tracks';
+import { sendEvent } from 'src/state/connection/actions';
+import getUser from 'src/state/selectors/get-user';
 
 import debugFactory from 'debug';
 const debug = debugFactory( 'happychat-client:ui:timeline' );
@@ -35,11 +38,61 @@ const messageParagraph = ( { message, isEdited, key, twemojiUrl } ) => (
 	</p>
 );
 
+class MessageLink extends React.Component {
+	handleClick = evt => {
+		const { href, messageId, sendEventMessage, user } = this.props;
+
+		sendEventMessage( `Opened ${href}` );
+		recordEvent( 'happychatclient_message_link_opened', {
+			message_id: messageId,
+			user_id: user.ID,
+			href
+		} );
+	};
+
+	handleMouseDown = evt => {
+		const { href, messageId, sendEventMessage, user } = this.props;
+
+		// Ignore left-clicks, the onClick handler will catch these
+		if (evt.button === 0) {
+			return;
+		}
+
+		this.props.sendEventMessage( `Alt-clicked ${href}` );
+		recordEvent( 'happychatclient_message_link_alt_click', {
+			message_id: messageId,
+			user_id: user.ID,
+			href
+		} );
+	};
+
+	render() {
+		const { children, href, key, rel, target } = this.props;
+		return (
+			<a
+				href={ href }
+				rel={ rel }
+				target={ target }
+				onClick={ this.handleClick }
+				onMouseDown={ this.handleMouseDown }
+				key={key}
+			>
+				{ children }
+			</a>
+		);
+	}
+}
+
+MessageLink = connect(
+	state => ({ user: getUser(state) }),
+	{ sendEventMessage: sendEvent },
+)(MessageLink);
+
 /*
  * Given a message and array of links contained within that message, returns the message
  * with clickable links inside of it.
  */
-const messageWithLinks = ( { message, isEdited, key, links, isExternalUrl } ) => {
+const messageWithLinks = ( { message, messageId, isEdited, links, isExternalUrl, onLinkClick, onLinkMouseDown } ) => {
 	const children = links.reduce(
 		( { parts, last }, [ url, startIndex, length ] ) => {
 			const text = url;
@@ -64,9 +117,9 @@ const messageWithLinks = ( { message, isEdited, key, links, isExternalUrl } ) =>
 			}
 
 			parts = parts.concat(
-				<a key={ parts.length } href={ href } rel={ rel } target={ target }>
+				<MessageLink key={ parts.length } href={ href } rel={ rel } target={ target } messageId={messageId}>
 					{ text }
-				</a>
+				</MessageLink>
 			);
 
 			return { parts, last: startIndex + length };
@@ -81,7 +134,7 @@ const messageWithLinks = ( { message, isEdited, key, links, isExternalUrl } ) =>
 	}
 
 	return (
-		<p key={ key }>
+		<p key={ messageId }>
 			{ children.parts }
 			{ isEdited && <small className="timeline__edited-flag">(edited)</small> }
 		</p>
@@ -110,15 +163,14 @@ const renderGroupedMessages = ( { item, isCurrentUser, twemojiUrl, isExternalUrl
 			<div className="happychat__message-text">
 				{ messageText( {
 					message: event.message,
-					name: event.name,
+					messageId: event.id,
 					isEdited: event.isEdited,
-					key: event.id,
 					links: event.links,
 					twemojiUrl,
 					isExternalUrl,
 				} ) }
-				{ rest.map( ( { message, isEdited, id: key, links } ) =>
-					messageText( { message, isEdited, key, links, twemojiUrl, isExternalUrl } )
+				{ rest.map( ( { message, isEdited, id, links } ) =>
+					messageText( { message, messageId: id, isEdited, links, twemojiUrl, isExternalUrl } )
 				) }
 			</div>
 		</div>


### PR DESCRIPTION
It can be hard to support users when we're not certain what step of a process they're on. This PR gives us a little more visibility, by sending an event message back to the HUD when a user clicks (or alt-clicks) a link. This acts as a signal to the operator that the customer has seen a link they've sent and looked at it.

It's possible this will end up being more noisy than useful, in which case we can try to find another way to send this information along.