### PR TITLE
Allow itemList to be required

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -111,6 +111,7 @@ The `entryOptions` property allows for configuring the text and behavior or Happ
 | `itemListTitle` | string | `Which product do you need help with?` | Title of item list menu. |
 | `itemList` | array | `[]` | Contains the options to be shown in the item list menu. They'll be rendered as a dropdown. If not provided, this section won't be shown. |
 | `itemListCustomFieldKey` | string | `null` | Add a key to save the result as a Custom Field on the chat. |
+| `itemListOptions` | object | `{}` | Options include `isRequired` |
 | `openTextFieldTitle` | string | `What is the URL of your site?` | Title for the textfield component. |
 | `openTextField` | object | `{}` | Contains conditions under which to show the text field. |
 | `openTextFieldCustomFieldKey` | string | `null` | Add a key to save the result as a Custom Field on the chat. |

--- a/src/form.js
+++ b/src/form.js
@@ -185,6 +185,7 @@ class ChatFormComponent {
 				secondaryOptionsTitle,
 				itemList,
 				itemListTitle,
+				itemListOptions,
 				defaultValues,
 				buttonText: { chat: buttonTextChat },
 			},
@@ -200,6 +201,7 @@ class ChatFormComponent {
 				secondaryOptionsTitle={ secondaryOptionsTitle }
 				itemList={ itemList }
 				itemListTitle={ itemListTitle }
+				itemListOptions={ itemListOptions }
 				defaultValues={ defaultValues }
 				showSubject={ false }
 				submitForm={ this.submitForm }
@@ -285,6 +287,7 @@ class TicketFormComponent {
 				secondaryOptionsTitle,
 				itemList,
 				itemListTitle,
+				itemListOptions,
 				openTextArea,
 				openTextAreaTitle,
 				openTextField,
@@ -352,6 +355,7 @@ class TicketFormComponent {
 						secondaryOptionsTitle={ secondaryOptionsTitle }
 						itemList={ itemList }
 						itemListTitle={ itemListTitle }
+						itemListOptions={ itemListOptions }
 						defaultValues={ defaultValues }
 						showSubject={ true }
 						openTextArea={ openTextArea }

--- a/src/lib/get-options/index.js
+++ b/src/lib/get-options/index.js
@@ -5,7 +5,7 @@ import find from 'lodash/find';
 
 export const getSelectedOption = ( options, defaultValue ) => {
 	if ( Array.isArray( options ) && options.length > 0 ) {
-		return find( options, { value: defaultValue } ) || options[ 0 ];
+		return find( options, { value: defaultValue } ) || {};
 	}
 	return {};
 };

--- a/src/ui/components/contact-form/index.jsx
+++ b/src/ui/components/contact-form/index.jsx
@@ -207,7 +207,20 @@ export class ContactForm extends React.Component {
 			openTextAreaValue,
 			primarySelected,
 			secondarySelected,
+			itemList,
+			itemSelected,
 		} = this.state;
+		const { itemListOptions } = this.props;
+
+		if (
+			Array.isArray( itemList ) &&
+			itemList.length > 0 &&
+			itemListOptions &&
+			itemListOptions.isRequired &&
+			! itemSelected.value
+		) {
+			return false;
+		}
 
 		const isOpenTextShown = options => {
 			const newOptions = filterByTargetValue(
@@ -448,6 +461,7 @@ ContactForm.propTypes = {
 	secondaryOptionsTitle: PropTypes.string,
 	itemListTitle: PropTypes.string,
 	itemList: PropTypes.array,
+	itemListOptions: PropTypes.object,
 	openTextField: PropTypes.object,
 	openTextFieldTitle: PropTypes.string,
 	openTextArea: PropTypes.object,

--- a/src/ui/components/select-dropdown/index.jsx
+++ b/src/ui/components/select-dropdown/index.jsx
@@ -136,7 +136,7 @@ class SelectDropdown extends Component {
 			return props.initialSelected;
 		}
 
-		return null;
+		return undefined;
 	}
 
 	getSelectedText() {

--- a/src/ui/components/select-dropdown/index.jsx
+++ b/src/ui/components/select-dropdown/index.jsx
@@ -136,12 +136,7 @@ class SelectDropdown extends Component {
 			return props.initialSelected;
 		}
 
-		if ( ! props.options.length ) {
-			return;
-		}
-
-		const selectedItem = find( props.options, value => ! value.isLabel );
-		return selectedItem && selectedItem.value;
+		return null;
 	}
 
 	getSelectedText() {

--- a/src/ui/components/select-dropdown/test/index.js
+++ b/src/ui/components/select-dropdown/test/index.js
@@ -88,7 +88,7 @@ describe( 'index', () => {
 		} );
 	} );
 
-	describe( 'getInitialSelectedItem', () => {
+		describe( 'getInitialSelectedItem', () => {
 		test( 'should return the initially selected value (if any)', () => {
 			const dropdown = shallowRenderDropdown( { initialSelected: 'drafts' } );
 			const initialSelectedValue = dropdown.instance().getInitialSelectedItem();
@@ -100,10 +100,10 @@ describe( 'index', () => {
 			expect( dropdown.instance().getInitialSelectedItem() ).toBeUndefined();
 		} );
 
-		test( "should return the first not-label option, when there isn't a preselected value", () => {
+		test( "should return `undefined`, when there isn't a preselected value", () => {
 			const dropdown = shallowRenderDropdown();
 			const initialSelectedValue = dropdown.instance().getInitialSelectedItem();
-			expect( initialSelectedValue ).toBe( 'published' );
+			expect( initialSelectedValue ).toBeUndefined();
 		} );
 	} );
 
@@ -115,7 +115,7 @@ describe( 'index', () => {
 		} );
 
 		test( 'should return the `label` associated to the selected option', () => {
-			const dropdown = shallowRenderDropdown();
+			const dropdown = shallowRenderDropdown( { initialSelected: 'published' } );
 			const initialSelectedText = dropdown.instance().getSelectedText();
 			expect( initialSelectedText ).toBe( 'Published' );
 		} );

--- a/targets/standalone/example-woo.html
+++ b/targets/standalone/example-woo.html
@@ -65,6 +65,7 @@
 						{"value":"2165910","label":"WooCommerce Shipping","primary":["broken"],"canChat":"true","description":["Support provided by WooCommerce. <a href=\"https:\/\/docs.woocommerce.com\/document\/marketplace-developers-customer-overview\/#section-3\" target=\"_blank\">Learn more<\/a> about what data will be shared with WooCommerce."]},
 						{"value":"583608","label":"WooCommerce Taxamo","primary":["broken"],"canChat":"true","description":["Support provided by WooCommerce. <a href=\"https:\/\/docs.woocommerce.com\/document\/marketplace-developers-customer-overview\/#section-3\" target=\"_blank\">Learn more<\/a> about what data will be shared with WooCommerce."]}
 					],
+					"itemListOptions": { "isRequired": true },
 					"defaultValues": {
 						"primary":"broken",
 						"item":""


### PR DESCRIPTION
The itemList was previously always selecting the first item by default (if no `defaultValues.item` was passed in). For Woo, this means that by default the "Core WooCommerce Plugin" is selected. But we frequently get users who have a question about a _different_ plugin, but they just skip the list because it's already filled out.

This PR lets you make `itemList` be required. When it is, and you don't set `defaultValues.item`, it will initialize blank and won't let you submit the form unless you pick an option:

https://user-images.githubusercontent.com/518059/125686450-f2363b8d-b823-4136-bae9-2ff5e43a4a71.mp4
