### PR TITLE
Add forceTicketForm option

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -30,6 +30,7 @@ with the following top-level properties:
 | `canChat` | bool | Optional | `true` | Whether the user can be offered chat or not. |
 | `entry` | string | Optional | `ENTRY_FORM` | What should be rendered as the first entry point for Happychat. Valid values are `ENTRY_FORM` (renders the contact form) `ENTRY_CHAT` (renders the chat form). |
 | `entryOptions` | object | Optional | `{}` | Configures Happychat entry points. See details below. |
+| `forceTicketForm` | bool | Optional | `false` | When true, forces the Ticket form to open, even if chat is available or the user has an active chat |
 | `groups` | array | Optional | `[WP.com]` | What group the chat session should be routed to. Valid values are `WP.com`, `woo`, and `jpop`. |
 | `nodeId` | string | Mandatory | `null` | The id of the HTMLNode where Happychat will be rendered. |
 | `plugins` | object | Optional | `{}` | Configuration for the plugins you want to activate. See details below.  |

--- a/src/api.js
+++ b/src/api.js
@@ -32,7 +32,7 @@ const api = {
 	 * @param {string} nodeId Mandatory. HTML Node id where Happychat will be rendered.
 	 * @param {Object} user Optional. Customer information.
 	 */
-	open: ( { authentication, canChat, entry, entryOptions, groups, nodeId, plugins, theme, user } ) => {
+	open: ( { authentication, canChat, entry, entryOptions, forceTicketForm, groups, nodeId, plugins, theme, user } ) => {
 		authenticator.init( authentication );
 
 		const targetNode = createTargetNode( { nodeId, theme, groups, entryOptions } );
@@ -44,6 +44,7 @@ const api = {
 				renderHappychat( targetNode, {
 					userObject,
 					canChat,
+					forceTicketForm,
 					groups,
 					entry,
 					entryOptions,

--- a/src/form.js
+++ b/src/form.js
@@ -420,6 +420,7 @@ class Form extends React.Component {
 	render() {
 		const {
 			authentication,
+			forceTicketForm,
 			isConnectionUninitialized,
 			isHappychatEnabled,
 			onInitConnection,
@@ -427,12 +428,14 @@ class Form extends React.Component {
 
 		return (
 			<div>
-				<HappychatConnection
-					authentication={ authentication }
-					isConnectionUninitialized={ isConnectionUninitialized }
-					isHappychatEnabled={ isHappychatEnabled }
-					onInitConnection={ onInitConnection }
-				/>
+				{ forceTicketForm !== true &&
+					<HappychatConnection
+						authentication={ authentication }
+						isConnectionUninitialized={ isConnectionUninitialized }
+						isHappychatEnabled={ isHappychatEnabled }
+						onInitConnection={ onInitConnection }
+					/>
+				}
 
 				{ this.getSupportComponent().render() }
 			</div>

--- a/src/index.js
+++ b/src/index.js
@@ -195,6 +195,7 @@ export const renderHappychat = (
 		userObject: { ID, email, username, display_name, avatar_URL, language },
 		groups = [ HAPPYCHAT_GROUP_WPCOM ],
 		canChat = true,
+		forceTicketForm = false,
 		entry = ENTRY_FORM,
 		entryOptions = {},
 		plugins = {},
@@ -220,7 +221,7 @@ export const renderHappychat = (
 
 	ReactDOM.render(
 		<Provider store={ store }>
-			<Happychat entry={ entry } canChat={ canChat } entryOptions={ entryOptions } plugins={ plugins } />
+			<Happychat entry={ entry } canChat={ canChat } entryOptions={ entryOptions } forceTicketForm={ forceTicketForm } plugins={ plugins } />
 		</Provider>,
 		targetNode
 	);

--- a/targets/standalone/example-woo.html
+++ b/targets/standalone/example-woo.html
@@ -94,7 +94,9 @@
 						site: 'en.support.wordpress.com'
 					},
 					'ssr-troubleshooting': {}
-				}
+				},
+
+				forceTicketForm: false,
 			});
 		});
 


### PR DESCRIPTION
This is a new top-level API option. When `forceTicketForm: true` is present, we want to make sure the user always sees the fallback ticket form — even if they are chat-eligible, and even if they have an ongoing chat.

We do this by preventing a socket connection from even being made when the option is enabled.