### PR TITLE
Links to *.woocommerce.com should include affiliate values in the URL

### DIFF
--- a/src/ui/components/timeline/index.jsx
+++ b/src/ui/components/timeline/index.jsx
@@ -21,7 +21,7 @@ import Emojify from 'src/ui/components/emojify';
 import scrollbleed from 'src/ui/components/scrollbleed';
 import { first, when, forEach } from './functional';
 import autoscroll from './autoscroll';
-import { addSchemeIfMissing, setUrlScheme } from './url';
+import { addSchemeIfMissing, addWooTrackers, setUrlScheme } from './url';
 import { recordEvent } from 'src/lib/tracks';
 import { sendEvent } from 'src/state/connection/actions';
 import getUser from 'src/state/selectors/get-user';
@@ -100,6 +100,7 @@ const messageWithLinks = ( { message, messageId, isEdited, links, isExternalUrl,
 			let target = null;
 
 			href = addSchemeIfMissing( href, 'http' );
+			href = addWooTrackers( href );
 			if ( isExternalUrl( href ) ) {
 				rel = 'noopener noreferrer';
 				target = '_blank';

--- a/src/ui/components/timeline/url.js
+++ b/src/ui/components/timeline/url.js
@@ -27,3 +27,18 @@ export const setUrlScheme = ( url, scheme ) => {
 
 	return url.replace( schemeRegex, schemeWithSlashes );
 };
+
+export const addWooTrackers = ( url ) => {
+	// All *.woocommerce.com links should include affiliate links to track referrals
+	try {
+		const newURL = new URL( url );
+		const wooDomain = 'woocommerce.com';
+		if ( newURL.host === wooDomain || newURL.host.endsWith( `.${ wooDomain }` ) ) {
+			newURL.searchParams.set( 'aff', '10486' );
+			newURL.searchParams.set( 'cid', '1131038' );
+		}
+		return newURL.toString();
+	} catch ( e ) {
+		return url;
+	}
+};


### PR DESCRIPTION
See pbUcTB-kY-p2

Adds affiliate values to URLs that go to any woocommerce.com subdomain, to help us track referrals from chat.