### PR TITLE
fix: force happychat socketio websocket connection

### DIFF
--- a/src/state/socketio.js
+++ b/src/state/socketio.js
@@ -31,7 +31,9 @@ const debug = debugFactory( 'happychat-client:socketio' );
 
 const buildConnection = socket =>
 	isString( socket )
-		? new IO( socket ) // If socket is an URL, connect to server.
+		? new IO( socket, {
+			transports: [ 'websocket' ],
+		} ) // If socket is an URL, connect to server.
 		: socket; // If socket is not an url, use it directly. Useful for testing.
 
 class Connection {
@@ -78,7 +80,10 @@ class Connection {
 						.on( 'message', message => dispatch( receiveMessage( message ) ) )
 						.on( 'message.optimistic', message => dispatch( receiveMessageOptimistic( message ) ) )
 						.on( 'message.update', message => dispatch( receiveMessageUpdate( message ) ) )
-						.on( 'typing', () => dispatch( receiveTyping() ) );
+						.on( 'typing', () => dispatch( receiveTyping() ) )
+						.on( 'reconnect_attempt', () => {
+							socket.io.opts.transports = [ 'polling', 'websocket' ];
+						} );
 				} )
 				.catch( e => reject( e ) );
 		} );


### PR DESCRIPTION
This PR aims to fix the connection issues we have after the server migration.
As we discussed it will fall back to the default behavior on a reconnection attempt.

Context: https://happychatp2.wordpress.com/2022/02/24/migrating-happy-chat-to-vips-new-infrastructure

Please let me know if you find any issues or have any suggestions