### PR TITLE
Add support for canSupport flag

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -160,9 +160,11 @@ this option will only be shown when the value of the selected primary option is 
 
 **itemList**
 
-In addition to the `value`, `label`, `canChat`, `description`, and `primary` properties, the options in this section can define a `secondary` option.
+In addition to the `value`, `label`, `canChat`, `description`, and `primary` properties, the options in this section can define a `secondary` and `canSupport` option.
 
 The `secondary` property works the same way that the `primary` one but taking into account the selected secondary option instead.
+
+When the `canSupport` property is set to `false`, it hides all fields after the item list selection. This is meant to be used when support for the given item is through a third-party.
 
 For example:
 

--- a/src/ui/components/contact-form/style.scss
+++ b/src/ui/components/contact-form/style.scss
@@ -18,6 +18,10 @@
 	.contact-form__item-list {
 		margin-bottom: 24px;
 
+		&.no-support {
+			margin-bottom: 0;
+		}
+
 		@include breakpoint( '>960px' ) {
 			margin-bottom: 32px;
 		}

--- a/targets/standalone/example.html
+++ b/targets/standalone/example.html
@@ -50,6 +50,16 @@
 						{ value: '2011', label: '2011 theme', primary: ['before-buy'], secondary: ['themes'] },
 						{ value: 'jp', label: 'Jetpack', secondary: ['plugins'], description: ['An awesome plugin.'] },
 						{ value: 'wc', label: 'WooCommerce', secondary: ['plugins'], canChat: false },
+						{
+							value: 'tiktok-for-woocommerce',
+							label: 'TikTok for WooCommerce',
+							secondary: ['plugins'],
+							description: [
+								'Click here to submit a support request for TikTok for WooCommerce',
+								'<a href="https://example.com" class="button is-primary" target="_blank" rel="noopener noreferrer">Contact TikTok support</a>',
+							],
+							canSupport: false,
+						},
 					],
 					itemListCustomFieldKey: 'devClientItemList',
 					openTextField: {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce.com/issues/15128
Related Slack conversation: https://a8c.slack.com/archives/C029S5LLB7D/p1674040918481819
Related change in WooCommerce.com: https://github.com/Automattic/woocommerce.com/pull/15766

#### Testing

```
npm install
npm start
```

Navigate to http://localhost:9000/. If you get an oAuth error, you might need to clear out the oAuth cookie manually using the dev tools.
Seems also the CSS is taken from production. So either believe me that the margin is set to zero when we hide the fields or sandbox `widgets.wp.com`, run `npm run build` and upload `targets/wordpress/happychat.css` to `~/public_html/widgets.wp.com/happychat/v1/happychat.css` on your sandbox. This should be the final result:

<img width="1122" alt="Screenshot 2023-01-26 at 12 37 27" src="https://user-images.githubusercontent.com/3392497/214839198-57a5185d-21e6-4e06-a91d-df54ed8c34e9.png">
